### PR TITLE
Use int64 for fields that require it

### DIFF
--- a/models/animation.go
+++ b/models/animation.go
@@ -10,5 +10,5 @@ type Animation struct {
 	Thumb        *PhotoSize `json:"thumb,omitempty"`
 	FileName     string     `json:"file_name,omitempty"`
 	MimeType     string     `json:"mime_type,omitempty"`
-	FileSize     int        `json:"file_size,omitempty"`
+	FileSize     int64      `json:"file_size,omitempty"`
 }

--- a/models/audio.go
+++ b/models/audio.go
@@ -9,6 +9,6 @@ type Audio struct {
 	Title        string     `json:"title,omitempty"`
 	FileName     string     `json:"file_name,omitempty"`
 	MimeType     string     `json:"mime_type,omitempty"`
-	FileSize     int        `json:"file_size,omitempty"`
+	FileSize     int64      `json:"file_size,omitempty"`
 	Thumb        *PhotoSize `json:"thumb,omitempty"`
 }

--- a/models/chat.go
+++ b/models/chat.go
@@ -65,7 +65,7 @@ type ChatLocation struct {
 
 // Chat https://core.telegram.org/bots/api#chat
 type Chat struct {
-	ID                                 int              `json:"id"`
+	ID                                 int64            `json:"id"`
 	Type                               string           `json:"type"`
 	Title                              string           `json:"title,omitempty"`
 	Username                           string           `json:"username,omitempty"`
@@ -86,6 +86,6 @@ type Chat struct {
 	HasProtectedContent                bool             `json:"has_protected_content,omitempty"`
 	StickerSetName                     string           `json:"sticker_set_name,omitempty"`
 	CanSetStickerSet                   bool             `json:"can_set_sticker_set,omitempty"`
-	LinkedChatID                       int              `json:"linked_chat_id,omitempty"`
+	LinkedChatID                       int64            `json:"linked_chat_id,omitempty"`
 	Location                           *ChatLocation    `json:"location,omitempty"`
 }

--- a/models/contact.go
+++ b/models/contact.go
@@ -5,6 +5,6 @@ type Contact struct {
 	PhoneNumber string `json:"phone_number"`
 	FirstName   string `json:"first_name"`
 	LastName    string `json:"last_name,omitempty"`
-	UserID      int    `json:"user_id,omitempty"`
+	UserID      int64  `json:"user_id,omitempty"`
 	VCard       string `json:"vcard,omitempty"`
 }

--- a/models/document.go
+++ b/models/document.go
@@ -7,5 +7,5 @@ type Document struct {
 	Thumb        *PhotoSize `json:"thumb,omitempty"`
 	FileName     string     `json:"file_name,omitempty"`
 	MimeType     string     `json:"mime_type,omitempty"`
-	FileSize     int        `json:"file_size,omitempty"`
+	FileSize     int64      `json:"file_size,omitempty"`
 }

--- a/models/file.go
+++ b/models/file.go
@@ -4,6 +4,6 @@ package models
 type File struct {
 	FileID       string `json:"file_id"`
 	FileUniqueID string `json:"file_unique_id"`
-	FileSize     int    `json:"file_size,omitempty"`
+	FileSize     int64  `json:"file_size,omitempty"`
 	FilePath     string `json:"file_path,omitempty"`
 }

--- a/models/message.go
+++ b/models/message.go
@@ -56,8 +56,8 @@ type Message struct {
 	SupergroupChatCreated         bool                           `json:"supergroup_chat_created,omitempty"`
 	ChannelChatCreated            bool                           `json:"channel_chat_created,omitempty"`
 	MessageAutoDeleteTimerChanged *MessageAutoDeleteTimerChanged `json:"message_auto_delete_timer_changed,omitempty"`
-	MigrateToChatID               int                            `json:"migrate_to_chat_id,omitempty"`
-	MigrateFromChatID             int                            `json:"migrate_from_chat_id,omitempty"`
+	MigrateToChatID               int64                          `json:"migrate_to_chat_id,omitempty"`
+	MigrateFromChatID             int64                          `json:"migrate_from_chat_id,omitempty"`
 	PinnedMessage                 *Message                       `json:"pinned_message,omitempty"`
 	Invoice                       *Invoice                       `json:"invoice,omitempty"`
 	SuccessfulPayment             *SuccessfulPayment             `json:"successful_payment,omitempty"`

--- a/models/user.go
+++ b/models/user.go
@@ -8,7 +8,7 @@ type UserProfilePhotos struct {
 
 // User https://core.telegram.org/bots/api#user
 type User struct {
-	ID                      int    `json:"id"`
+	ID                      int64  `json:"id"`
 	IsBot                   bool   `json:"is_bot"`
 	FirstName               string `json:"first_name,omitempty"`
 	LastName                string `json:"last_name,omitempty"`

--- a/models/video.go
+++ b/models/video.go
@@ -10,5 +10,5 @@ type Video struct {
 	Thumb        *PhotoSize `json:"thumb,omitempty"`
 	FileName     string     `json:"file_name,omitempty"`
 	MimeType     string     `json:"mime_type,omitempty"`
-	FileSize     int        `json:"file_size,omitempty"`
+	FileSize     int64      `json:"file_size,omitempty"`
 }

--- a/models/video_note.go
+++ b/models/video_note.go
@@ -7,5 +7,5 @@ type VideoNote struct {
 	Length       int        `json:"length"`
 	Duration     int        `json:"duration"`
 	Thumb        *PhotoSize `json:"thumb,omitempty"`
-	FileSize     int        `json:"file_size,omitempty"`
+	FileSize64   int        `json:"file_size,omitempty"`
 }

--- a/models/voice.go
+++ b/models/voice.go
@@ -6,5 +6,5 @@ type Voice struct {
 	FileUniqueID string `json:"file_unique_id"`
 	Duration     int    `json:"duration"`
 	MimeType     string `json:"mime_type,omitempty"`
-	FileSize     int    `json:"file_size,omitempty"`
+	FileSize64   int    `json:"file_size,omitempty"`
 }


### PR DESCRIPTION
Golang's int is 32 or 64 bits depending on the platform so int64 should be used explicitly to
ensure these fields don't overflow.

I did not put much thought into backwards compatibility.

Golang int notes: https://go.dev/tour/basics/11
Telegram API: https://core.telegram.org/bots/api