### PR TITLE
Fix MenuButtonWebApp to fit Telegram API

### DIFF
--- a/models/menu_button.go
+++ b/models/menu_button.go
@@ -58,7 +58,7 @@ func (MenuButtonCommands) menuButtonTag() {}
 type MenuButtonWebApp struct {
 	Type   string     `json:"type" rules:"required,equals:web_app"`
 	Text   string     `json:"text" rules:"required"`
-	WebApp WebAppInfo `json:"web_app_info" rules:"required"`
+	WebApp WebAppInfo `json:"web_app" rules:"required"`
 }
 
 func (MenuButtonWebApp) menuButtonTag() {}


### PR DESCRIPTION
There is a bug with MenuButtonWebApp. Property with URL should has name `web_app` not `web_app_info`. Link to the docs: https://core.telegram.org/bots/api#menubuttonwebapp