### PR TITLE
Set IsAnonymous poll param to pointer

### DIFF
--- a/methods_params.go
+++ b/methods_params.go
@@ -255,7 +255,7 @@ type SendPollParams struct {
 	MessageThreadID          int                    `json:"message_thread_id,omitempty"`
 	Question                 string                 `json:"question"`
 	Options                  []string               `json:"options"`
-	IsAnonymous              bool                   `json:"is_anonymous,omitempty"`
+	IsAnonymous              *bool                   `json:"is_anonymous,omitempty"`
 	Type                     string                 `json:"type,omitempty"`
 	AllowsMultipleAnswers    bool                   `json:"allows_multiple_answers,omitempty"`
 	CorrectOptionID          int                    `json:"correct_option_id"`


### PR DESCRIPTION
Sets the type of SendPollParams.IsAnonymous to a pointer to a boolean to address the case where setting the value to false (I want a non-anonymous poll) would omit the value, leading to the default of true being selected. 

This does mean it's now slightly more awkward to define - have to pass a pointer to a bool value now rather than just a normal bool, but it does fix the issue. Open to suggestions for better approaches if you have any. 

Test Results:
```
❯ go test
PASS
ok      github.com/go-telegram/bot      0.864s
```

Closes #25 