### PR TITLE
Fix error parsing inline keyboard button click reply message

### DIFF
--- a/models/message.go
+++ b/models/message.go
@@ -81,5 +81,5 @@ type Message struct {
 	VoiceChatEnded                *VoiceChatEnded                `json:"voice_chat_ended,omitempty"`
 	VoiceChatParticipantsInvited  *VoiceChatParticipantsInvited  `json:"voice_chat_participants_invited,omitempty"`
 	WebAppData                    *WebAppData                    `json:"web_app_data,omitempty"`
-	ReplyMarkup                   ReplyMarkup                    `json:"reply_markup,omitempty"`
+	ReplyMarkup                   InlineKeyboardMarkup           `json:"reply_markup,omitempty"`
 }


### PR DESCRIPTION
First of all, thank you for the great work. I'm actively developing a Telegram bot, and recently migrated from https://github.com/go-telegram-bot-api/telegram-bot-api to this package, and I'm pleased using your packge. Great work in the simple, and fluent API design!

## Bug Report
After upgrading to [v0.7.7](https://github.com/go-telegram/bot/releases/tag/v0.7.7), I'm seeing duplicate error logs on receiving updates containing inline keyboard button reply messages similar to the following:
```txt
2023/04/26 10:53:09 [TGBOT] [ERROR] error get updates, error decode response result for method getUpdates, json: cannot unmarshal object into Go struct field Message.callback_query.message.reply_markup of type models.ReplyMarkup
2023/04/26 10:53:09 [TGBOT] [ERROR] error get updates, error decode response result for method getUpdates, json: cannot unmarshal object into Go struct field Message.callback_query.message.reply_markup of type models.ReplyMarkup
2023/04/26 10:53:10 [TGBOT] [ERROR] error get updates, error decode response result for method getUpdates, json: cannot unmarshal object into Go struct field Message.callback_query.message.reply_markup of type models.ReplyMarkup
2023/04/26 10:53:10 [TGBOT] [ERROR] error get updates, error decode response result for method getUpdates, json: cannot unmarshal object into Go struct field Message.callback_query.message.reply_markup of type models.ReplyMarkup
2023/04/26 10:53:11 [TGBOT] [ERROR] error get updates, error decode response result for method getUpdates, json: cannot unmarshal object into Go struct field Message.callback_query.message.reply_markup of type models.ReplyMarkup
2023/04/26 10:53:13 [TGBOT] [ERROR] error get updates, error decode response result for method getUpdates, json: cannot unmarshal object into Go struct field Message.callback_query.message.reply_markup of type models.ReplyMarkup
2023/04/26 10:53:16 [TGBOT] [ERROR] error get updates, error decode response result for method getUpdates, json: cannot unmarshal object into Go struct field Message.callback_query.message.reply_markup of type models.ReplyMarkup
```
## Steps to Reproduce
1. Set proper Telegram Bot Token in the `EXAMPLE_TELEGRAM_BOT_TOKEN` environment variable 
2. Run the `inline_keyboard` example package: `go run ./examples/inline_keyboard/`
3. Send message with "button" text to the robot
4. You'll see bunch of repetitive error logs in your terminal

## How I Fixed
There are two points to mention that I considered for this fix:
- According to [Telegram Bot API documentation for the Message type](https://core.telegram.org/bots/api#message), which I found in the comments of the `models.Message` struct type, the `reply_markup` field is of type [InlineKeyboardMarkup](https://core.telegram.org/bots/api#inlinekeyboardmarkup), which corresponds to `models.InlineKeyboardMarkup` struct type.
- As you changed the `models.ReplyMarkup` type from an alias of the type `any` to an interface type, there's no way for the `encoding/json.Unmarshal` function to parse it as there is **no actual type** as its parse destination.

I hope that this makes sense. Please let me know if there are any concerns, or issues that I forgot.

Cheers