### PR TITLE
Fixed EscapeMarkdown for \ symbol

### DIFF
--- a/common.go
+++ b/common.go
@@ -9,7 +9,7 @@ import (
 
 // escape special symbols in text for MarkdownV2 parse mode
 
-var shouldBeEscaped = "_*[]()~`>#+-=|{}.!"
+var shouldBeEscaped = "_*[]()~`>#+-=|{}.!\\"
 
 // EscapeMarkdown escapes special symbols for Telegram MarkdownV2 syntax
 func EscapeMarkdown(s string) string {


### PR DESCRIPTION
You forgot to escape the \ character in the EscapeMarkdown function, which caused me some errors.

Details in this pr from a similar library that also has this disease:
https://github.com/go-telegram-bot-api/telegram-bot-api/pull/604