### PR TITLE
Fix typo for setChatDescription params

### DIFF
--- a/methods_params.go
+++ b/methods_params.go
@@ -414,7 +414,7 @@ type SetChatTitleParams struct {
 
 type SetChatDescriptionParams struct {
 	ChatID      any    `json:"chat_id"`
-	Description string `json:"title"`
+	Description string `json:"description"`
 }
 
 type PinChatMessageParams struct {


### PR DESCRIPTION
From telegram [bot API docs](https://core.telegram.org/bots/api#setchatdescription) the setChatDescription params should be description instead of title.
