### PR TITLE
Add support of handling different updates

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -43,9 +43,13 @@ func (h handler) match(update *models.Update) bool {
 	var data string
 	switch h.handlerType {
 	case HandlerTypeMessageText:
-		data = update.Message.Text
+		if update.Message != nil {
+			data = update.Message.Text
+		}
 	case HandlerTypeCallbackQueryData:
-		data = update.CallbackQuery.Data
+		if update.CallbackQuery != nil {
+			data = update.CallbackQuery.Data
+		}
 	}
 
 	if h.matchType == MatchTypeExact {


### PR DESCRIPTION
Currently, there's no way to handle updates, which does not contain Message or CallbackQuery:

```
func (b *Bot) ProcessUpdate(ctx context.Context, upd *models.Update) {
	h := b.defaultHandlerFunc

	defer func() {
		applyMiddlewares(h, b.middlewares...)(ctx, b, upd)
	}()

	if upd.Message != nil {
		h = b.findHandler(HandlerTypeMessageText, upd)
		return
	}
	if upd.CallbackQuery != nil {
		h = b.findHandler(HandlerTypeCallbackQueryData, upd)
		return
	}
}
```

Which is actually a problem, because you can't for example handle channel post updates.