### PR TITLE
add WithAllowedUpdates option

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -51,6 +51,8 @@ type Bot struct {
 	isDebug          bool
 	checkInitTimeout time.Duration
 
+	allowedUpdates AllowedUpdates
+
 	updates chan *models.Update
 }
 

--- a/get_updates.go
+++ b/get_updates.go
@@ -15,11 +15,13 @@ const (
 )
 
 type getUpdatesParams struct {
-	Offset         int64    `json:"offset,omitempty"`
-	Limit          int      `json:"limit,omitempty"`
-	Timeout        int      `json:"timeout,omitempty"`
-	AllowedUpdates []string `json:"allowed_updates,omitempty"`
+	Offset         int64          `json:"offset,omitempty"`
+	Limit          int            `json:"limit,omitempty"`
+	Timeout        int            `json:"timeout,omitempty"`
+	AllowedUpdates AllowedUpdates `json:"allowed_updates,omitempty"`
 }
+
+type AllowedUpdates []string
 
 // GetUpdates https://core.telegram.org/bots/api#getupdates
 func (b *Bot) getUpdates(ctx context.Context, wg *sync.WaitGroup) {
@@ -48,6 +50,10 @@ func (b *Bot) getUpdates(ctx context.Context, wg *sync.WaitGroup) {
 		params := &getUpdatesParams{
 			Timeout: int((b.pollTimeout - time.Second).Seconds()),
 			Offset:  atomic.LoadInt64(&b.lastUpdateID) + 1,
+		}
+
+		if b.allowedUpdates != nil {
+			params.AllowedUpdates = b.allowedUpdates
 		}
 
 		var updates []*models.Update

--- a/options.go
+++ b/options.go
@@ -86,3 +86,10 @@ func WithSkipGetMe() Option {
 		b.skipGetMe = true
 	}
 }
+
+// WithAllowedUpdates allows to set custom params for getUpdates method
+func WithAllowedUpdates(params AllowedUpdates) Option {
+	return func(b *Bot) {
+		b.allowedUpdates = params
+	}
+}


### PR DESCRIPTION
from https://core.telegram.org/bots/api#getupdates

> Specify an empty list to receive all update types except chat_member, message_reaction, and message_reaction_count (default). If not specified, the previous setting will be used.