### PR TITLE
exit from waitUpdates function when context is terminated

### DIFF
--- a/wait_updates.go
+++ b/wait_updates.go
@@ -12,6 +12,7 @@ func (b *Bot) waitUpdates(ctx context.Context, wg *sync.WaitGroup) {
 	for {
 		select {
 		case <-ctx.Done():
+			return
 		case upd := <-b.updates:
 			b.ProcessUpdate(ctx, upd)
 		}


### PR DESCRIPTION
After the new changes return from the waitUpdates function was lost when the passed context was terminated.