### PR TITLE
Use any type for ChatID in SetGameScoreParams and GetGameHighScoreParams

### DIFF
--- a/methods_params.go
+++ b/methods_params.go
@@ -924,14 +924,14 @@ type SetGameScoreParams struct {
 	Score              int   `json:"score"`
 	Force              bool  `json:"force,omitempty"`
 	DisableEditMessage bool  `json:"disable_edit_message,omitempty"`
-	ChatID             int   `json:"chat_id,omitempty"`
+	ChatID             any   `json:"chat_id,omitempty"`
 	MessageID          int   `json:"message_id,omitempty"`
 	InlineMessageID    int   `json:"inline_message_id,omitempty"`
 }
 
 type GetGameHighScoresParams struct {
 	UserID          int64 `json:"user_id"`
-	ChatID          int   `json:"chat_id,omitempty"`
+	ChatID          any   `json:"chat_id,omitempty"`
 	MessageID       int   `json:"message_id,omitempty"`
 	InlineMessageID int   `json:"inline_message_id,omitempty"`
 }


### PR DESCRIPTION
`SetGameScoreParams` and `GetGameHighScoresParams` structs use `int` as their data type for ChatID which is not large enough to store the actual ChatID from Telegram. Use `any` type since it's used everywhere else.