### PR TITLE
fix: getGameHighScores api call returns an array of high scores instead of a single object

### DIFF
--- a/methods.go
+++ b/methods.go
@@ -840,8 +840,8 @@ func (b *Bot) SetGameScore(ctx context.Context, params *SetGameScoreParams) (*mo
 }
 
 // GetGameHighScores https://core.telegram.org/bots/api#getgamehighscores
-func (b *Bot) GetGameHighScores(ctx context.Context, params *GetGameHighScoresParams) (*models.GameHighScore, error) {
-	result := &models.GameHighScore{}
-	err := b.rawRequest(ctx, "getGameHighScores", params, result)
+func (b *Bot) GetGameHighScores(ctx context.Context, params *GetGameHighScoresParams) ([]*models.GameHighScore, error) {
+	var result []*models.GameHighScore
+	err := b.rawRequest(ctx, "getGameHighScores", params, &result)
 	return result, err
 }

--- a/methods_params.go
+++ b/methods_params.go
@@ -924,14 +924,14 @@ type SetGameScoreParams struct {
 	Score              int   `json:"score"`
 	Force              bool  `json:"force,omitempty"`
 	DisableEditMessage bool  `json:"disable_edit_message,omitempty"`
-	ChatID             int   `json:"chat_id,omitempty"`
+	ChatID             any   `json:"chat_id,omitempty"`
 	MessageID          int   `json:"message_id,omitempty"`
 	InlineMessageID    int   `json:"inline_message_id,omitempty"`
 }
 
 type GetGameHighScoresParams struct {
 	UserID          int64 `json:"user_id"`
-	ChatID          int   `json:"chat_id,omitempty"`
+	ChatID          any   `json:"chat_id,omitempty"`
 	MessageID       int   `json:"message_id,omitempty"`
 	InlineMessageID int   `json:"inline_message_id,omitempty"`
 }


### PR DESCRIPTION
As per described in the documentation here: [https://core.telegram.org/bots/api#getgamehighscores](url)