### PR TITLE
fix: getGameHighScores returns an array of high scores instead of a single GameHighScore

### DIFF
--- a/methods.go
+++ b/methods.go
@@ -840,8 +840,8 @@ func (b *Bot) SetGameScore(ctx context.Context, params *SetGameScoreParams) (*mo
 }
 
 // GetGameHighScores https://core.telegram.org/bots/api#getgamehighscores
-func (b *Bot) GetGameHighScores(ctx context.Context, params *GetGameHighScoresParams) (*models.GameHighScore, error) {
-	result := &models.GameHighScore{}
-	err := b.rawRequest(ctx, "getGameHighScores", params, result)
+func (b *Bot) GetGameHighScores(ctx context.Context, params *GetGameHighScoresParams) ([]*models.GameHighScore, error) {
+	var result []*models.GameHighScore
+	err := b.rawRequest(ctx, "getGameHighScores", params, &result)
 	return result, err
 }

--- a/methods_test.go
+++ b/methods_test.go
@@ -1377,7 +1377,7 @@ func TestBot_Methods(t *testing.T) {
 	})
 
 	t.Run("GetGameHighScores", func(t *testing.T) {
-		c := &httpClient{t: t, resp: `{"score":42}`, reqFields: map[string]string{
+		c := &httpClient{t: t, resp: `[{"score":42}]`, reqFields: map[string]string{
 			"chat_id": "123",
 		}}
 		b := &Bot{client: c}
@@ -1385,7 +1385,7 @@ func TestBot_Methods(t *testing.T) {
 			ChatID: 123,
 		})
 		assertNoErr(t, err)
-		assertEqualInt(t, 42, resp.Score)
+		assertEqualInt(t, 42, resp[0].Score)
 	})
 
 }


### PR DESCRIPTION
As per described in the documentation here: [https://core.telegram.org/bots/api#getgamehighscores](url)
Changed the test to reflect this.