### PR TITLE
feat: add middlewares for handler

### DIFF
--- a/examples/middleware/main.go
+++ b/examples/middleware/main.go
@@ -59,10 +59,11 @@ func singleFlight(next bot.HandlerFunc) bot.HandlerFunc {
 	sf := sync.Map{}
 	return func(ctx context.Context, b *bot.Bot, update *models.Update) {
 		if update.CallbackQuery != nil {
-			if _, loaded := sf.LoadOrStore(update.CallbackQuery.ID, struct{}{}); loaded {
+			key := update.CallbackQuery.Message.Message.ID
+			if _, loaded := sf.LoadOrStore(key, struct{}{}); loaded {
 				return
 			}
-			defer sf.Delete(update.CallbackQuery.ID)
+			defer sf.Delete(key)
 			next(ctx, b, update)
 		}
 	}

--- a/examples/middleware/main.go
+++ b/examples/middleware/main.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"sync"
 
 	"github.com/go-telegram/bot"
 	"github.com/go-telegram/bot/models"
@@ -28,6 +29,10 @@ func main() {
 		panic(err)
 	}
 
+	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, "", bot.MatchTypeExact, func(ctx context.Context, b *bot.Bot, update *models.Update) {
+		log.Printf("callback query data: %s", update.CallbackQuery.Data)
+	}, singleFlight)
+
 	b.Start(ctx)
 }
 
@@ -46,6 +51,20 @@ func showMessageWithUserName(next bot.HandlerFunc) bot.HandlerFunc {
 			log.Printf("%s say: %s", update.Message.From.FirstName, update.Message.Text)
 		}
 		next(ctx, b, update)
+	}
+}
+
+// singleFlight is a middleware that ensures that only one callback query is processed at a time.
+func singleFlight(next bot.HandlerFunc) bot.HandlerFunc {
+	sf := sync.Map{}
+	return func(ctx context.Context, b *bot.Bot, update *models.Update) {
+		if update.CallbackQuery != nil {
+			if _, loaded := sf.LoadOrStore(update.CallbackQuery.ID, struct{}{}); loaded {
+				return
+			}
+			defer sf.Delete(update.CallbackQuery.ID)
+			next(ctx, b, update)
+		}
 	}
 }
 

--- a/handlers.go
+++ b/handlers.go
@@ -63,7 +63,7 @@ func (h handler) match(update *models.Update) bool {
 	return false
 }
 
-func (b *Bot) RegisterHandlerMatchFunc(matchFunc MatchFunc, f HandlerFunc) string {
+func (b *Bot) RegisterHandlerMatchFunc(matchFunc MatchFunc, f HandlerFunc, m ...Middleware) string {
 	b.handlersMx.Lock()
 	defer b.handlersMx.Unlock()
 
@@ -72,7 +72,7 @@ func (b *Bot) RegisterHandlerMatchFunc(matchFunc MatchFunc, f HandlerFunc) strin
 	h := handler{
 		matchType: matchTypeFunc,
 		matchFunc: matchFunc,
-		handler:   f,
+		handler:   applyMiddlewares(f, m...),
 	}
 
 	b.handlers[id] = h
@@ -80,7 +80,7 @@ func (b *Bot) RegisterHandlerMatchFunc(matchFunc MatchFunc, f HandlerFunc) strin
 	return id
 }
 
-func (b *Bot) RegisterHandlerRegexp(handlerType HandlerType, re *regexp.Regexp, f HandlerFunc) string {
+func (b *Bot) RegisterHandlerRegexp(handlerType HandlerType, re *regexp.Regexp, f HandlerFunc, m ...Middleware) string {
 	b.handlersMx.Lock()
 	defer b.handlersMx.Unlock()
 
@@ -90,7 +90,7 @@ func (b *Bot) RegisterHandlerRegexp(handlerType HandlerType, re *regexp.Regexp, 
 		handlerType: handlerType,
 		matchType:   matchTypeRegexp,
 		re:          re,
-		handler:     f,
+		handler:     applyMiddlewares(f, m...),
 	}
 
 	b.handlers[id] = h
@@ -98,7 +98,7 @@ func (b *Bot) RegisterHandlerRegexp(handlerType HandlerType, re *regexp.Regexp, 
 	return id
 }
 
-func (b *Bot) RegisterHandler(handlerType HandlerType, pattern string, matchType MatchType, f HandlerFunc) string {
+func (b *Bot) RegisterHandler(handlerType HandlerType, pattern string, matchType MatchType, f HandlerFunc, m ...Middleware) string {
 	b.handlersMx.Lock()
 	defer b.handlersMx.Unlock()
 
@@ -108,7 +108,7 @@ func (b *Bot) RegisterHandler(handlerType HandlerType, pattern string, matchType
 		handlerType: handlerType,
 		matchType:   matchType,
 		pattern:     pattern,
-		handler:     f,
+		handler:     applyMiddlewares(f, m...),
 	}
 
 	b.handlers[id] = h


### PR DESCRIPTION
Sometimes it is necessary to add middleware for individual handlers.

I added an example in the example, for instance, sometimes when we handle CallbackQuery, it may not be so quick, and users may click the button multiple times, resulting in multiple requests arriving simultaneously. At this point, we can use singleFlight to ensure that only one request is processed.