### PR TITLE
[Feature] add 'HandlerTypeCallbackQueryGameShortName'

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -12,6 +12,7 @@ type HandlerType int
 const (
 	HandlerTypeMessageText HandlerType = iota
 	HandlerTypeCallbackQueryData
+	HandlerTypeCallbackQueryGameShortName
 )
 
 type MatchType int
@@ -46,6 +47,8 @@ func (h handler) match(update *models.Update) bool {
 		data = update.Message.Text
 	case HandlerTypeCallbackQueryData:
 		data = update.CallbackQuery.Data
+	case HandlerTypeCallbackQueryGameShortName:
+		data = update.CallbackQuery.GameShortName
 	}
 
 	if h.matchType == MatchTypeExact {

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -167,3 +167,26 @@ func TestBot_RegisterUnregisterHandler(t *testing.T) {
 		t.Fatalf("handler not found")
 	}
 }
+
+func Test_match_exact_game(t *testing.T) {
+	b := &Bot{
+		handlersMx: &sync.RWMutex{},
+		handlers:   map[string]handler{},
+	}
+
+	id := b.RegisterHandler(HandlerTypeCallbackQueryGameShortName, "xxx", MatchTypeExact, nil)
+
+	h := b.handlers[id]
+	u := models.Update{
+		ID: 42,
+		CallbackQuery: &models.CallbackQuery{
+			ID:            "1000",
+			GameShortName: "xxx",
+		},
+	}
+
+	res := h.match(&u)
+	if !res {
+		t.Error("unexpected true result")
+	}
+}


### PR DESCRIPTION
## Problem

A handler with type `HandlerTypeCallbackQueryData` will be matched by `update.CallbackQuery.Data`.
So, you MUST use `RegisterHandlerMatchFunc` to add a handler for CallbackQuery with `game_short_name` (the `data` field may be empty. See more https://core.telegram.org/bots/api#callbackquery).

This feature will help you add a handler for CallbackQuery with `game_short_name` more easily.

## Solution

Add const `HandlerTypeCallbackQueryGameShortName`.
A handler with type `HandlerTypeCallbackQueryGameShortName` will be matched by `update.CallbackQuery.GameShortName`.