### PR TITLE
Support change bot token

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -98,6 +98,10 @@ func New(token string, options ...Option) (*Bot, error) {
 	return b, nil
 }
 
+func (b *Bot) SetToken (token string) {
+	b.token = token
+}
+
 // StartWebhook starts the Bot with webhook mode
 func (b *Bot) StartWebhook(ctx context.Context) {
 	wg := sync.WaitGroup{}


### PR DESCRIPTION
I have a web server serving a lot of bots and have a case for optimization reasons to replace the token, rather than construct a new object in memory