### PR TITLE
Fix arm64 panic

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -31,6 +31,8 @@ type MatchFunc func(update *models.Update) bool
 
 // Bot represents Telegram Bot main object
 type Bot struct {
+	lastUpdateID     int64
+
 	url                string
 	token              string
 	pollTimeout        time.Duration
@@ -51,7 +53,6 @@ type Bot struct {
 	handlers   []handler
 
 	client           HttpClient
-	lastUpdateID     int64
 	isDebug          bool
 	checkInitTimeout time.Duration
 


### PR DESCRIPTION
Users of [evcc.io](https://evcc.io) have just reported this panic on arm64:

```
panic: unaligned 64-bit atomic operation
goroutine 246 [running]:
internal/runtime/atomic.panicUnaligned()
        internal/runtime/atomic/unaligned.go:8 +0x24
internal/runtime/atomic.Load64(0x6521a1c)
        internal/runtime/atomic/atomic_arm.s:291 +0x14
github.com/go-telegram/bot.(*Bot).getUpdates(0x65219a8, {0x3373ff4, 0x5639a88}, 0x6c928c0)
        github.com/go-telegram/bot@v1.10.0/get_updates.go:52 +0x2c4
```

According to https://pkg.go.dev/sync/atomic#pkg-note-BUG:

> On ARM, 386, and 32-bit MIPS, it is the caller's responsibility to arrange for 64-bit alignment of 64-bit words accessed atomically. The first word in a variable or in an allocated struct, array, or slice can be relied upon to be 64-bit aligned.

Rearranging the order of the structure fixes this.

