### PR TITLE
feat: add handler type for photo captions

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ b, err := bot.New("YOUR_BOT_TOKEN_FROM_BOTFATHER", opts...)
 - `WithMiddlewares(middlewares ...Middleware)` - add middlewares
 - `WithMessageTextHandler(pattern string, matchType MatchType, handler HandlerFunc)` - add handler for Message.Text field
 - `WithCallbackQueryDataHandler(pattern string, matchType MatchType, handler HandlerFunc)` - add handler for CallbackQuery.Data field
+- `WithPhotoCaptionHandler` - add handler for Message.Caption field
 - `WithDefaultHandler(handler HandlerFunc)` - add default handler
 - `WithDebug()` - enable debug mode
 - `WithErrorsHandler(handler ErrorsHandler)` - add errors handler
@@ -189,7 +190,7 @@ b, err := bot.New("YOUR_BOT_TOKEN_FROM_BOTFATHER", opts...)
 
 ## Message.Text and CallbackQuery.Data handlers
 
-For your convenience, you can use `Message.Text` and `CallbackQuery.Data` handlers.
+For your convenience, you can use `Message.Text`, `CallbackQuery.Data` and `Message.Caption` handlers.
 
 An example:
 

--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ In this example, the handler will be called when the user sends `/start` message
 Handler Types:
 - `HandlerTypeMessageText` - for Update.Message.Text field
 - `HandlerTypeCallbackQueryData` - for Update.CallbackQuery.Data field
+- `HandlerTypePhotoCaption` - for Update.Message.Caption field
 
 RegisterHandler returns a handler ID string. You can use it to remove the handler later.
 

--- a/handlers.go
+++ b/handlers.go
@@ -13,6 +13,7 @@ const (
 	HandlerTypeMessageText HandlerType = iota
 	HandlerTypeCallbackQueryData
 	HandlerTypeCallbackQueryGameShortName
+	HandlerTypePhotoCaption
 )
 
 type MatchType int
@@ -57,6 +58,8 @@ func (h handler) match(update *models.Update) bool {
 		data = update.CallbackQuery.Data
 	case HandlerTypeCallbackQueryGameShortName:
 		data = update.CallbackQuery.GameShortName
+	case HandlerTypePhotoCaption:
+		data = update.Message.Caption
 	}
 
 	if h.matchType == MatchTypeExact {

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -62,6 +62,24 @@ func Test_match_exact(t *testing.T) {
 	}
 }
 
+func Test_match_caption_exact(t *testing.T) {
+	b := &Bot{}
+
+	id := b.RegisterHandler(HandlerTypePhotoCaption, "xxx", MatchTypeExact, nil)
+
+	h := findHandler(b, id)
+
+	res := h.match(&models.Update{Message: &models.Message{Caption: "zzz"}})
+	if res {
+		t.Error("unexpected true result")
+	}
+
+	res = h.match(&models.Update{Message: &models.Message{Caption: "xxx"}})
+	if !res {
+		t.Error("unexpected false result")
+	}
+}
+
 func Test_match_prefix(t *testing.T) {
 	b := &Bot{}
 

--- a/options.go
+++ b/options.go
@@ -39,6 +39,14 @@ func WithCallbackQueryDataHandler(pattern string, matchType MatchType, handler H
 	}
 }
 
+// WithPhotoCaptionHandler allows to set handler for incoming photos with caption
+// Also you can use *bot.RegisterHandler function after bot creation
+func WithPhotoCaptionHandler(pattern string, matchType MatchType, handler HandlerFunc) Option {
+	return func(b *Bot) {
+		b.RegisterHandler(HandlerTypePhotoCaption, pattern, matchType, handler)
+	}
+}
+
 // WithDefaultHandler allows to set default handler for incoming updates
 func WithDefaultHandler(handler HandlerFunc) Option {
 	return func(b *Bot) {

--- a/process_update_test.go
+++ b/process_update_test.go
@@ -134,6 +134,36 @@ func Test_findHandler(t *testing.T) {
 	}
 }
 
+func Test_findPhotoCaptionHandler(t *testing.T) {
+	var called bool
+	h := func(ctx context.Context, bot *Bot, update *models.Update) {
+		called = true
+	}
+
+	bot := &Bot{
+		defaultHandlerFunc: h,
+	}
+
+	// Register a handler
+	bot.handlers = append(bot.handlers, handler{
+		id:          "test",
+		handlerType: HandlerTypePhotoCaption,
+		matchType:   MatchTypeExact,
+		pattern:     "test",
+		handler:     h,
+	})
+
+	ctx := context.Background()
+	upd := &models.Update{Message: &models.Message{Caption: "test"}}
+
+	handler := bot.findHandler(upd)
+	handler(ctx, bot, upd)
+
+	if !called {
+		t.Fatal("Expected registered handler to be called")
+	}
+}
+
 func Test_findHandler_Default(t *testing.T) {
 	var called bool
 	h := func(ctx context.Context, bot *Bot, update *models.Update) {


### PR DESCRIPTION
With incoming messages that come with a photo, `HandlerTypeMessageText` does not catch those as they are within `Update.Message.Caption` and not `Text`.

I initially thought about adding a check for `Caption` if `Text` is empty in the `HandlerTypeMessageText` case, but I think a separate type is cleaner. Let me know what you think!