### PR TITLE
stopRecieveUpdates method

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -59,7 +59,8 @@ type Bot struct {
 
 	allowedUpdates AllowedUpdates
 
-	updates chan *models.Update
+	updates            chan *models.Update
+	stopReceiveUpdates chan struct{}
 }
 
 // New creates new Bot instance
@@ -81,7 +82,8 @@ func New(token string, options ...Option) (*Bot, error) {
 		checkInitTimeout:   defaultCheckInitTimeout,
 		workers:            defaultWorkers,
 
-		updates: make(chan *models.Update, defaultUpdatesChanCap),
+		updates:            make(chan *models.Update, defaultUpdatesChanCap),
+		stopReceiveUpdates: make(chan struct{}),
 	}
 
 	for _, o := range options {
@@ -146,6 +148,11 @@ func (b *Bot) Start(ctx context.Context) {
 	}
 
 	wg.Wait()
+}
+
+// StopReceiveUpdates stops receiving updates
+func (b *Bot) StopReceiveUpdates() {
+	b.stopReceiveUpdates <- struct{}{}
 }
 
 func defaultErrorsHandler(err error) {

--- a/wait_updates.go
+++ b/wait_updates.go
@@ -13,6 +13,8 @@ func (b *Bot) waitUpdates(ctx context.Context, wg *sync.WaitGroup) {
 		select {
 		case <-ctx.Done():
 			return
+		case <-b.stopReceiveUpdates:
+			return
 		case upd := <-b.updates:
 			b.ProcessUpdate(ctx, upd)
 		}


### PR DESCRIPTION
a method that allows you to stop receiving updates without completely stopping (without calling the Stop() method)