### PR TITLE
Change type of Stickers field in CreateNewStickerSetParams struct

### DIFF
--- a/methods_params.go
+++ b/methods_params.go
@@ -818,12 +818,12 @@ type UploadStickerFileParams struct {
 }
 
 type CreateNewStickerSetParams struct {
-	UserID          int64            `json:"user_id"`
-	Name            string           `json:"name"`
-	Title           string           `json:"title"`
-	Stickers        []models.Sticker `json:"stickers"`
-	StickerType     string           `json:"sticker_type,omitempty"`
-	NeedsRepainting bool             `json:"needs_repainting,omitempty"`
+	UserID          int64                 `json:"user_id"`
+	Name            string                `json:"name"`
+	Title           string                `json:"title"`
+	Stickers        []models.InputSticker `json:"stickers"`
+	StickerType     string                `json:"sticker_type,omitempty"`
+	NeedsRepainting bool                  `json:"needs_repainting,omitempty"`
 }
 
 type AddStickerToSetParams struct {


### PR DESCRIPTION
Change type to the correct one, as in `createNewStickerSet` method [documentation](https://core.telegram.org/bots/api#createnewstickerset)