### PR TITLE
Make copy text button optional for inline keyboard button

### DIFF
--- a/models/reply_markup.go
+++ b/models/reply_markup.go
@@ -39,7 +39,7 @@ type InlineKeyboardButton struct {
 	SwitchInlineQuery            string                       `json:"switch_inline_query,omitempty"`
 	SwitchInlineQueryCurrentChat string                       `json:"switch_inline_query_current_chat,omitempty"`
 	SwitchInlineQueryChosenChat  *SwitchInlineQueryChosenChat `json:"switch_inline_query_chosen_chat,omitempty"`
-	CopyText                     CopyTextButton               `json:"copy_text,omitempty"`
+	CopyText                     *CopyTextButton              `json:"copy_text,omitempty"`
 	CallbackGame                 *CallbackGame                `json:"callback_game,omitempty"`
 	Pay                          bool                         `json:"pay,omitempty"`
 }


### PR DESCRIPTION
Most of the time, I don't need to create a CopyTextButton for the Inline Keyboard. However, at the moment, this is not possible due to structural limitations.

fixes 
ERROR bad request, Bad Request: BUTTON_COPY_TEXT_INVALID