### PR TITLE
add `MatchTypeCommandStartMaybeWithBotUsernameSuffix` command match method

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -36,6 +36,7 @@ type Bot struct {
 
 	url                string
 	token              string
+	username           string
 	pollTimeout        time.Duration
 	skipGetMe          bool
 	webhookSecretToken string
@@ -92,10 +93,11 @@ func New(token string, options ...Option) (*Bot, error) {
 	defer cancel()
 
 	if !b.skipGetMe {
-		_, err := b.GetMe(ctx)
+		botInfo, err := b.GetMe(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("error call getMe, %w", err)
 		}
+		b.username = botInfo.Username
 	}
 
 	return b, nil
@@ -119,6 +121,13 @@ func (b *Bot) SetToken(token string) {
 // Token returns the bot token
 func (b *Bot) Token() string {
 	return b.token
+}
+
+// Username returns the bot username without `@` prefix
+//
+// Return empty string if bot with the `bot.WithSkipGetMe()` option
+func (b *Bot) Username() string {
+	return b.username
 }
 
 // StartWebhook starts the Bot with webhook mode

--- a/bot_test.go
+++ b/bot_test.go
@@ -396,3 +396,13 @@ func TestBot_SetToken(t *testing.T) {
 		t.Errorf("SetToken() = %s, want %s", b.token, "123456:xxx")
 	}
 }
+
+func TestBot_Username(t *testing.T) {
+	b := &Bot{username: "example_bot"}
+
+	username := b.Username()
+
+	if username != "example_bot" {
+		t.Errorf("Username() = %s, want %s", username, "example_bot")
+	}
+}

--- a/handlers.go
+++ b/handlers.go
@@ -105,7 +105,7 @@ func (h handler) match(update *models.Update) bool {
 	if h.matchType == MatchTypeCommandStartMaybeWithBotUsernameSuffix {
 		for _, e := range entities {
 			if e.Type == models.MessageEntityTypeBotCommand {
-				if e.Offset == 0 && (data[e.Offset+1:e.Offset+e.Length] == h.pattern || data[e.Offset+1:e.Offset+e.Length] == h.pattern + "@" + h.username) {
+				if e.Offset == 0 && (data[e.Offset+1:e.Offset+e.Length] == h.pattern || data[e.Offset+1:e.Offset+e.Length] == h.pattern+"@"+h.username) {
 					return true
 				}
 			}

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -319,7 +319,7 @@ func Test_match_command_start(t *testing.T) {
 			Message: &models.Message{
 				Text: "/bar",
 				Entities: []models.MessageEntity{
-					{Type: models.MessageEntityTypeBotCommand, Offset: 2, Length: 4},
+					{Type: models.MessageEntityTypeBotCommand, Offset: 0, Length: 4},
 				},
 			},
 		}

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -480,7 +480,6 @@ func Test_match_command_start(t *testing.T) {
 		}
 	})
 
-
 	// wrong command
 	t.Run("start maybe with username suffix 7, no", func(t *testing.T) {
 		b := &Bot{

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -329,4 +329,355 @@ func Test_match_command_start(t *testing.T) {
 			t.Error("unexpected result")
 		}
 	})
+
+	// correct command
+	t.Run("start maybe with username suffix 1, yes", func(t *testing.T) {
+		b := &Bot{
+			username: "foo_bot",
+		}
+
+		id := b.RegisterHandler(HandlerTypeMessageText, "foo", MatchTypeCommandStartMaybeWithBotUsernameSuffix, nil)
+
+		h := findHandler(b, id)
+		u := models.Update{
+			ID: 42,
+			Message: &models.Message{
+				Text: "/foo",
+				Entities: []models.MessageEntity{
+					{Type: models.MessageEntityTypeBotCommand, Offset: 0, Length: 4},
+				},
+			},
+		}
+
+		res := h.match(&u)
+		if !res {
+			t.Error("unexpected result")
+		}
+	})
+
+	// correct command, correct username
+	t.Run("start maybe with username suffix 2, yes", func(t *testing.T) {
+		b := &Bot{
+			username: "foo_bot",
+		}
+
+		id := b.RegisterHandler(HandlerTypeMessageText, "foo", MatchTypeCommandStartMaybeWithBotUsernameSuffix, nil)
+
+		h := findHandler(b, id)
+		u := models.Update{
+			ID: 42,
+			Message: &models.Message{
+				Text: "/foo@foo_bot",
+				Entities: []models.MessageEntity{
+					{Type: models.MessageEntityTypeBotCommand, Offset: 0, Length: 12},
+				},
+			},
+		}
+
+		res := h.match(&u)
+		if !res {
+			t.Error("unexpected result")
+		}
+	})
+
+	// correct command, wrong username
+	t.Run("start maybe with username suffix 3, no", func(t *testing.T) {
+		b := &Bot{
+			username: "foo_bot",
+		}
+
+		id := b.RegisterHandler(HandlerTypeMessageText, "foo", MatchTypeCommandStartMaybeWithBotUsernameSuffix, nil)
+
+		h := findHandler(b, id)
+		u := models.Update{
+			ID: 42,
+			Message: &models.Message{
+				Text: "/foo@other_bot",
+				Entities: []models.MessageEntity{
+					{Type: models.MessageEntityTypeBotCommand, Offset: 0, Length: 14},
+				},
+			},
+		}
+
+		res := h.match(&u)
+		if res {
+			t.Error("unexpected result")
+		}
+	})
+
+	// correct command, with prefix
+	t.Run("start maybe with username suffix 4, no", func(t *testing.T) {
+		b := &Bot{
+			username: "foo_bot",
+		}
+
+		id := b.RegisterHandler(HandlerTypeMessageText, "foo", MatchTypeCommandStartMaybeWithBotUsernameSuffix, nil)
+
+		h := findHandler(b, id)
+		u := models.Update{
+			ID: 42,
+			Message: &models.Message{
+				Text: "a /foo",
+				Entities: []models.MessageEntity{
+					{Type: models.MessageEntityTypeBotCommand, Offset: 2, Length: 4},
+				},
+			},
+		}
+
+		res := h.match(&u)
+		if res {
+			t.Error("unexpected result")
+		}
+	})
+
+	// correct command, with prefix, correct username
+	t.Run("start maybe with username suffix 5, no", func(t *testing.T) {
+		b := &Bot{
+			username: "foo_bot",
+		}
+
+		id := b.RegisterHandler(HandlerTypeMessageText, "foo", MatchTypeCommandStartMaybeWithBotUsernameSuffix, nil)
+
+		h := findHandler(b, id)
+		u := models.Update{
+			ID: 42,
+			Message: &models.Message{
+				Text: "a /foo@foo_bot",
+				Entities: []models.MessageEntity{
+					{Type: models.MessageEntityTypeBotCommand, Offset: 2, Length: 12},
+				},
+			},
+		}
+
+		res := h.match(&u)
+		if res {
+			t.Error("unexpected result")
+		}
+	})
+
+	// correct command, with prefix, wrong username
+	t.Run("start maybe with username suffix 6, no", func(t *testing.T) {
+		b := &Bot{
+			username: "foo_bot",
+		}
+
+		id := b.RegisterHandler(HandlerTypeMessageText, "foo", MatchTypeCommandStartMaybeWithBotUsernameSuffix, nil)
+
+		h := findHandler(b, id)
+		u := models.Update{
+			ID: 42,
+			Message: &models.Message{
+				Text: "a /foo@other_bot",
+				Entities: []models.MessageEntity{
+					{Type: models.MessageEntityTypeBotCommand, Offset: 2, Length: 14},
+				},
+			},
+		}
+
+		res := h.match(&u)
+		if res {
+			t.Error("unexpected result")
+		}
+	})
+
+
+	// wrong command
+	t.Run("start maybe with username suffix 7, no", func(t *testing.T) {
+		b := &Bot{
+			username: "foo_bot",
+		}
+
+		id := b.RegisterHandler(HandlerTypeMessageText, "foo", MatchTypeCommandStartMaybeWithBotUsernameSuffix, nil)
+
+		h := findHandler(b, id)
+		u := models.Update{
+			ID: 42,
+			Message: &models.Message{
+				Text: "/bar",
+				Entities: []models.MessageEntity{
+					{Type: models.MessageEntityTypeBotCommand, Offset: 0, Length: 4},
+				},
+			},
+		}
+
+		res := h.match(&u)
+		if res {
+			t.Error("unexpected result")
+		}
+	})
+
+	// wrong command, correct username
+	t.Run("start maybe with username suffix 8, no", func(t *testing.T) {
+		b := &Bot{
+			username: "foo_bot",
+		}
+
+		id := b.RegisterHandler(HandlerTypeMessageText, "foo", MatchTypeCommandStartMaybeWithBotUsernameSuffix, nil)
+
+		h := findHandler(b, id)
+		u := models.Update{
+			ID: 42,
+			Message: &models.Message{
+				Text: "/bar@foo_bot",
+				Entities: []models.MessageEntity{
+					{Type: models.MessageEntityTypeBotCommand, Offset: 0, Length: 12},
+				},
+			},
+		}
+
+		res := h.match(&u)
+		if res {
+			t.Error("unexpected result")
+		}
+	})
+
+	// wrong command, wrong username
+	t.Run("start maybe with username suffix 9, no", func(t *testing.T) {
+		b := &Bot{
+			username: "foo_bot",
+		}
+
+		id := b.RegisterHandler(HandlerTypeMessageText, "foo", MatchTypeCommandStartMaybeWithBotUsernameSuffix, nil)
+
+		h := findHandler(b, id)
+		u := models.Update{
+			ID: 42,
+			Message: &models.Message{
+				Text: "/bar@other_bot",
+				Entities: []models.MessageEntity{
+					{Type: models.MessageEntityTypeBotCommand, Offset: 0, Length: 14},
+				},
+			},
+		}
+
+		res := h.match(&u)
+		if res {
+			t.Error("unexpected result")
+		}
+	})
+
+	// wrong command, with prefix
+	t.Run("start maybe with username suffix 10, no", func(t *testing.T) {
+		b := &Bot{
+			username: "foo_bot",
+		}
+
+		id := b.RegisterHandler(HandlerTypeMessageText, "foo", MatchTypeCommandStartMaybeWithBotUsernameSuffix, nil)
+
+		h := findHandler(b, id)
+		u := models.Update{
+			ID: 42,
+			Message: &models.Message{
+				Text: "a /bar",
+				Entities: []models.MessageEntity{
+					{Type: models.MessageEntityTypeBotCommand, Offset: 2, Length: 4},
+				},
+			},
+		}
+
+		res := h.match(&u)
+		if res {
+			t.Error("unexpected result")
+		}
+	})
+
+	// wrong command, with prefix, correct username
+	t.Run("start maybe with username suffix 11, no", func(t *testing.T) {
+		b := &Bot{
+			username: "foo_bot",
+		}
+
+		id := b.RegisterHandler(HandlerTypeMessageText, "foo", MatchTypeCommandStartMaybeWithBotUsernameSuffix, nil)
+
+		h := findHandler(b, id)
+		u := models.Update{
+			ID: 42,
+			Message: &models.Message{
+				Text: "a /bar@foo_bot",
+				Entities: []models.MessageEntity{
+					{Type: models.MessageEntityTypeBotCommand, Offset: 2, Length: 12},
+				},
+			},
+		}
+
+		res := h.match(&u)
+		if res {
+			t.Error("unexpected result")
+		}
+	})
+
+	// wrong command, with prefix, wrong username
+	t.Run("start maybe with username suffix 12, no", func(t *testing.T) {
+		b := &Bot{
+			username: "foo_bot",
+		}
+
+		id := b.RegisterHandler(HandlerTypeMessageText, "foo", MatchTypeCommandStartMaybeWithBotUsernameSuffix, nil)
+
+		h := findHandler(b, id)
+		u := models.Update{
+			ID: 42,
+			Message: &models.Message{
+				Text: "a /bar@other_bot",
+				Entities: []models.MessageEntity{
+					{Type: models.MessageEntityTypeBotCommand, Offset: 2, Length: 14},
+				},
+			},
+		}
+
+		res := h.match(&u)
+		if res {
+			t.Error("unexpected result")
+		}
+	})
+
+	// correct command, no username, correct username
+	t.Run("start maybe with username suffix 13, no", func(t *testing.T) {
+		b := &Bot{
+			// username: "foo_bot", // no username
+		}
+
+		id := b.RegisterHandler(HandlerTypeMessageText, "foo", MatchTypeCommandStartMaybeWithBotUsernameSuffix, nil)
+
+		h := findHandler(b, id)
+		u := models.Update{
+			ID: 42,
+			Message: &models.Message{
+				Text: "/foo@foo_bot",
+				Entities: []models.MessageEntity{
+					{Type: models.MessageEntityTypeBotCommand, Offset: 0, Length: 12},
+				},
+			},
+		}
+
+		res := h.match(&u)
+		if res {
+			t.Error("unexpected result")
+		}
+	})
+
+	// correct command, no username, wrong username
+	t.Run("start maybe with username suffix 14, no", func(t *testing.T) {
+		b := &Bot{
+			// username: "foo_bot", // no username
+		}
+
+		id := b.RegisterHandler(HandlerTypeMessageText, "foo", MatchTypeCommandStartMaybeWithBotUsernameSuffix, nil)
+
+		h := findHandler(b, id)
+		u := models.Update{
+			ID: 42,
+			Message: &models.Message{
+				Text: "/foo@other_bot",
+				Entities: []models.MessageEntity{
+					{Type: models.MessageEntityTypeBotCommand, Offset: 0, Length: 14},
+				},
+			},
+		}
+
+		res := h.match(&u)
+		if res {
+			t.Error("unexpected result")
+		}
+	})
 }


### PR DESCRIPTION
Create a field name `username` in the [`Bot`](https://github.com/Interstellar750/bot/blob/e815ce62c31c2bd7cb0119116085e01bb182b69d/bot.go#L39) and [`handler`](https://github.com/Interstellar750/bot/blob/e815ce62c31c2bd7cb0119116085e01bb182b69d/handlers.go#L40) structures to match commands like `/command@username_bot`.

Also created a `bot.Username()` `string` method to return the bot's username (without `@`).

When using `bot.New()` without `bot.WithSkipGetMe()` option, the `username` field is filling by following code:
```diff
func New(token string, options ...Option) (*Bot, error) {
	// other code...
	if !b.skipGetMe {
-		_, err := b.GetMe(ctx)
+		botInfo, err := b.GetMe(ctx)
		if err != nil {
			return nil, fmt.Errorf("error call getMe, %w", err)
		}
+		b.username = botInfo.Username
	}

	return b, nil
}
```

If with the `bot.WithSkipGetMe()` option, this match method will work the same as `MatchTypeCommandStartOnly`, then `bot.Username()` will return an empty string.

This PR may not be good. If you think it is not good, you can close it directly. Some issues mentioned that this is needed, or are there other better ways?
