### PR TITLE
style: replace empty `interface{}` with `any`

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -152,7 +152,7 @@ func defaultErrorsHandler(err error) {
 	log.Printf("[TGBOT] [ERROR] %v", err)
 }
 
-func defaultDebugHandler(format string, args ...interface{}) {
+func defaultDebugHandler(format string, args ...any) {
 	log.Printf("[TGBOT] [DEBUG] "+format, args...)
 }
 
@@ -160,7 +160,7 @@ func defaultHandler(_ context.Context, _ *Bot, update *models.Update) {
 	log.Printf("[TGBOT] [UPDATE] %+v", update)
 }
 
-func (b *Bot) error(format string, args ...interface{}) {
+func (b *Bot) error(format string, args ...any) {
 	b.errorsHandler(fmt.Errorf(format, args...))
 }
 

--- a/webhook_handler_test.go
+++ b/webhook_handler_test.go
@@ -17,7 +17,7 @@ type mockDebugHandler struct {
 	messages []string
 }
 
-func (h *mockDebugHandler) Handle(format string, args ...interface{}) {
+func (h *mockDebugHandler) Handle(format string, args ...any) {
 	h.messages = append(h.messages, format)
 }
 
@@ -52,7 +52,7 @@ func TestWebhookHandler_Success(t *testing.T) {
 	bot := &Bot{
 		updates: make(chan *models.Update, 1),
 		isDebug: true,
-		debugHandler: func(format string, args ...interface{}) {
+		debugHandler: func(format string, args ...any) {
 			debugHandler.Handle(format, args...)
 		},
 		errorsHandler: func(err error) {
@@ -86,7 +86,7 @@ func TestWebhookHandler_ReadBodyError(t *testing.T) {
 	errorsHandler := &mockErrorsHandler{}
 
 	bot := &Bot{
-		debugHandler: func(format string, args ...interface{}) {
+		debugHandler: func(format string, args ...any) {
 			debugHandler.Handle(format, args...)
 		},
 		errorsHandler: func(err error) {
@@ -114,7 +114,7 @@ func TestWebhookHandler_DecodeError(t *testing.T) {
 	errorsHandler := &mockErrorsHandler{}
 
 	bot := &Bot{
-		debugHandler: func(format string, args ...interface{}) {
+		debugHandler: func(format string, args ...any) {
 			debugHandler.Handle(format, args...)
 		},
 		errorsHandler: func(err error) {
@@ -144,7 +144,7 @@ func TestWebhookHandler_ContextDone(t *testing.T) {
 
 	bot := &Bot{
 		updates: make(chan *models.Update, 1),
-		debugHandler: func(format string, args ...interface{}) {
+		debugHandler: func(format string, args ...any) {
 			debugHandler.Handle(format, args...)
 		},
 		errorsHandler: func(err error) {


### PR DESCRIPTION
As mentioned in readme, this library uses go version 1.18+. `any` introduced in go 1.18 and suggested to replace `interface{}`, so I replaced it.