### PR TITLE
fix: Changed the ProtectContent field from bool to *bool in SendPaidMediaParams

### DIFF
--- a/methods_params.go
+++ b/methods_params.go
@@ -264,7 +264,7 @@ type SendPaidMediaParams struct {
 	CaptionEntities         []models.MessageEntity          `json:"caption_entities,omitempty"`
 	ShowCaptionAboveMedia   bool                            `json:"show_caption_above_media,omitempty"`
 	DisableNotification     bool                            `json:"disable_notification,omitempty"`
-	ProtectContent          bool                            `json:"protect_content,omitempty"`
+	ProtectContent          *bool                           `json:"protect_content,omitempty"`
 	AllowPaidBroadcast      bool                            `json:"allow_paid_broadcast,omitempty"`
 	SuggestedPostParameters *models.SuggestedPostParameters `json:"suggested_post_parameters,omitempty"`
 	ReplyParameters         *models.ReplyParameters         `json:"reply_parameters,omitempty"`


### PR DESCRIPTION
## Problem

When setting `ProtectContent: false` in `SendPaidMediaParams`, the field is omitted from the JSON due to the `omitempty` tag on the boolean field. This prevents users from explicitly disabling content protection for paid media, as the Telegram API never receives the `protect_content: false` value.

## Solution

Changed the `ProtectContent` field from `bool` to `*bool` (pointer) in `SendPaidMediaParams`. This is the idiomatic Go solution for optional boolean fields in JSON APIs, as it properly distinguishes between:
- `nil` (not set, omitted from JSON due to `omitempty`)
- `*false` (explicitly set to false, included in JSON as `false`)
- `*true` (explicitly set to true, included in JSON as `true`)

## Impact

This change allows developers to explicitly control content protection for paid media:
- When `ProtectContent` is `nil`, the field is omitted (current behavior for unset fields)
- When set to `&falseValue`, users can save/forward the content
- When set to `&trueValue`, content is protected from saving/forwarding

## Testing

Tested with a Telegram bot sending paid media:
```go
protectContent := false
params := &bot.SendPaidMediaParams{
    ChatID:         chatID,
    StarCount:      5,
    Media:          []models.InputPaidMedia{media},
    ProtectContent: &protectContent, // Now properly sends 'protect_content: false'
}
```

After this fix, the API correctly receives `protect_content: false` and users can save the images as intended.

## Note on Breaking Change

This is technically a breaking change as it changes the field type from `bool` to `*bool`. However:
1. The `SendPaidMediaParams` is a relatively new addition for Telegram Stars paid media
2. The current implementation is broken for the `false` case
3. Users can easily adapt by taking a pointer to their boolean value

If maintaining backward compatibility is critical, an alternative would be to add a new field like `ProtectContentPtr *bool` and deprecate the original, but this seems unnecessarily complex for fixing what is essentially a bug.