### PR TITLE
Reduce cyclomatic complexity in handler.match() and 100% test coverage for handlers.go

### DIFF
--- a/handlers_test.go
+++ b/handlers_test.go
@@ -332,6 +332,22 @@ func Test_match_command_start(t *testing.T) {
 	})
 }
 
+func Test_match_NilUpdateMessageIsFalse(t *testing.T) {
+	b := &Bot{}
+	id := b.RegisterHandler(HandlerTypeMessageText, "foo", MatchTypeCommand, nil)
+	h := findHandler(b, id)
+
+	u := models.Update{
+		ID:      42,
+		Message: nil,
+	}
+
+	res := h.match(&u)
+	if res {
+		t.Error("want 'false', but got 'true'")
+	}
+}
+
 func Test_getDataFromUpdate(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -358,7 +358,7 @@ func Test_getDataFromUpdate(t *testing.T) {
 		wantError    bool
 	}{
 		{
-			name: "HandlerTypeMessageText - valid message",
+			name: "HandlerTypeMessageText - valid message, is ok",
 			update: &models.Update{
 				Message: &models.Message{
 					Text: "Hello, world!",
@@ -375,7 +375,7 @@ func Test_getDataFromUpdate(t *testing.T) {
 			wantError: false,
 		},
 		{
-			name: "HandlerTypeMessageText - nil message",
+			name: "HandlerTypeMessageText - nil message, is error",
 			update: &models.Update{
 				Message: nil,
 			},
@@ -385,7 +385,7 @@ func Test_getDataFromUpdate(t *testing.T) {
 			wantError:    true,
 		},
 		{
-			name: "HandlerTypeMessageText - empty message",
+			name: "HandlerTypeMessageText - empty message, is ok",
 			update: &models.Update{
 				Message: &models.Message{
 					Text:     "",
@@ -398,7 +398,7 @@ func Test_getDataFromUpdate(t *testing.T) {
 			wantError:    false,
 		},
 		{
-			name: "HandlerTypeCallbackQueryData - valid callback query",
+			name: "HandlerTypeCallbackQueryData - valid callback query, is ok",
 			update: &models.Update{
 				CallbackQuery: &models.CallbackQuery{
 					Data: "callback_data",
@@ -410,7 +410,7 @@ func Test_getDataFromUpdate(t *testing.T) {
 			wantError:    false,
 		},
 		{
-			name: "HandlerTypeCallbackQueryData - nil callback query",
+			name: "HandlerTypeCallbackQueryData - nil callback query, is error",
 			update: &models.Update{
 				CallbackQuery: nil,
 			},
@@ -420,7 +420,7 @@ func Test_getDataFromUpdate(t *testing.T) {
 			wantError:    true,
 		},
 		{
-			name: "HandlerTypeCallbackQueryData - empty data",
+			name: "HandlerTypeCallbackQueryData - empty data, is ok",
 			update: &models.Update{
 				CallbackQuery: &models.CallbackQuery{
 					Data: "",
@@ -432,7 +432,7 @@ func Test_getDataFromUpdate(t *testing.T) {
 			wantError:    false,
 		},
 		{
-			name: "HandlerTypeCallbackQueryGameShortName - valid game short name",
+			name: "HandlerTypeCallbackQueryGameShortName - valid game short name, is ok",
 			update: &models.Update{
 				CallbackQuery: &models.CallbackQuery{
 					GameShortName: "snake_game",
@@ -444,7 +444,7 @@ func Test_getDataFromUpdate(t *testing.T) {
 			wantError:    false,
 		},
 		{
-			name: "HandlerTypeCallbackQueryGameShortName - nil callback query",
+			name: "HandlerTypeCallbackQueryGameShortName - nil callback query, is error",
 			update: &models.Update{
 				CallbackQuery: nil,
 			},
@@ -454,7 +454,7 @@ func Test_getDataFromUpdate(t *testing.T) {
 			wantError:    true,
 		},
 		{
-			name: "HandlerTypePhotoCaption - valid photo caption",
+			name: "HandlerTypePhotoCaption - valid photo caption, is ok",
 			update: &models.Update{
 				Message: &models.Message{
 					Caption: "Photo caption",
@@ -471,7 +471,7 @@ func Test_getDataFromUpdate(t *testing.T) {
 			wantError: false,
 		},
 		{
-			name: "HandlerTypePhotoCaption - nil message",
+			name: "HandlerTypePhotoCaption - nil message, is error",
 			update: &models.Update{
 				Message: nil,
 			},
@@ -481,7 +481,7 @@ func Test_getDataFromUpdate(t *testing.T) {
 			wantError:    true,
 		},
 		{
-			name: "HandlerTypePhotoCaption - empty caption",
+			name: "HandlerTypePhotoCaption - empty caption, is ok",
 			update: &models.Update{
 				Message: &models.Message{
 					Caption:         "",
@@ -494,7 +494,7 @@ func Test_getDataFromUpdate(t *testing.T) {
 			wantError:    false,
 		},
 		{
-			name: "Invalid handler type",
+			name: "Invalid handler type returns empty values, is ok",
 			update: &models.Update{
 				Message: &models.Message{
 					Text: "some text",


### PR DESCRIPTION
## Problem
- Closes #221 

## Solution - what PR does
- Comprehensive decomposition of the function `(h handler) match(update *models.Update)`. To reduce cyclomatic complexity, and improve testability.

Now, for `handlers.go` file, the following indicators apply:
```
$ gocyclo handlers.go
9 bot getDataFromUpdate handlers.go:72:1
9 bot (handler).match handlers.go:44:1
5 bot (handler).matchCommandStartOnly handlers.go:137:1
4 bot (handler).matchCommand handlers.go:125:1
4 bot extractCommand handlers.go:116:1
3 bot (*Bot).UnregisterHandler handlers.go:205:1
1 bot (*Bot).RegisterHandler handlers.go:186:1
1 bot (*Bot).RegisterHandlerRegexp handlers.go:167:1
1 bot (*Bot).RegisterHandlerMatchFunc handlers.go:149:1
1 bot (handler).matchRegexp handlers.go:112:1
1 bot (handler).matchContains handlers.go:108:1
1 bot (handler).matchPrefix handlers.go:104:1
1 bot (handler).matchExact handlers.go:100:1
```

Previous:
```
$ gocyclo handlers.go                                                                                                                                                               
23 bot (handler).match handlers.go:43:1
3 bot (*Bot).UnregisterHandler handlers.go:165:1
1 bot (*Bot).RegisterHandler handlers.go:146:1
1 bot (*Bot).RegisterHandlerRegexp handlers.go:127:1
1 bot (*Bot).RegisterHandlerMatchFunc handlers.go:109:1
```

- Achieving 100% branch coverage for the all added code.
- Achieving 100% test coverage for the `handlers.go` file.
<img width="753" height="49" alt="image" src="https://github.com/user-attachments/assets/287b8588-c455-4f93-9755-e74912ed7721" />
