### PR TITLE
feat(models): add missing User fields from Bot API 9.3

### DIFF
--- a/models/user.go
+++ b/models/user.go
@@ -20,4 +20,6 @@ type User struct {
 	CanReadAllGroupMessages bool   `json:"can_read_all_group_messages,omitempty"`
 	SupportInlineQueries    bool   `json:"support_inline_queries,omitempty"`
 	CanConnectToBusiness    bool   `json:"can_connect_to_business,omitempty"`
+	HasMainWebApp           bool   `json:"has_main_web_app,omitempty"`
+	HasTopicsEnabled        bool   `json:"has_topics_enabled,omitempty"`
 }


### PR DESCRIPTION
## Summary

This PR adds the missing fields from the Telegram Bot API User object to ensure full API compatibility with Bot API 9.3.

## Changes

### Added Fields
- `HasMainWebApp` (`has_main_web_app`) - Indicates if the bot has a main Web App (returned only in `getMe`)
- `HasTopicsEnabled` (`has_topics_enabled`) - Indicates if the bot has forum topic mode enabled in private chats (returned only in `getMe`)

## API Reference
- [Telegram Bot API - User](https://core.telegram.org/bots/api#user)

## Breaking Changes
None - these are additive fields with `omitempty` tags, so existing code will continue to work.

## Related
- Bot API 9.3 release notes mention these fields for topics in private chats