### PR TITLE
feat: add InlineKeyboard Builder

### DIFF
--- a/examples/inline_keyboard_builder/main.go
+++ b/examples/inline_keyboard_builder/main.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+
+	"github.com/go-telegram/bot"
+	"github.com/go-telegram/bot/keyboards"
+	"github.com/go-telegram/bot/models"
+)
+
+func main() {
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer cancel()
+
+	opts := []bot.Option{
+		bot.WithDefaultHandler(handler),
+		bot.WithCallbackQueryDataHandler("button", bot.MatchTypePrefix, callbackHandler),
+	}
+
+	b, err := bot.New(os.Getenv("EXAMPLE_TELEGRAM_BOT_TOKEN"), opts...)
+	if nil != err {
+		panic(err)
+	}
+
+	b.Start(ctx)
+}
+
+func handler(ctx context.Context, b *bot.Bot, update *models.Update) {
+	kb := keyboards.NewInlineKeyboard()
+
+	kb.Row(
+		keyboards.InlineKeyboardButton("Button 1", "button_1"),
+		keyboards.InlineKeyboardButton("Button 2", "button_2"),
+	)
+	kb.Row(
+		keyboards.InlineKeyboardURL("Google", "https://google.com"),
+	)
+
+	b.SendMessage(ctx, &bot.SendMessageParams{
+		ChatID:      update.Message.Chat.ID,
+		Text:        "Here is your keyboard",
+		ReplyMarkup: kb.Build(),
+	})
+}
+
+func callbackHandler(ctx context.Context, b *bot.Bot, update *models.Update) {
+	b.AnswerCallbackQuery(ctx, &bot.AnswerCallbackQueryParams{
+		CallbackQueryID: update.CallbackQuery.ID,
+		ShowAlert:       true,
+		Text:            fmt.Sprintf("You clicked %s", update.CallbackQuery.Data),
+	})
+}

--- a/keyboards/inline_keyboard.go
+++ b/keyboards/inline_keyboard.go
@@ -1,0 +1,92 @@
+package keyboards
+
+import "github.com/go-telegram/bot/models"
+
+type InlineKeyboard struct {
+	rows [][]models.InlineKeyboardButton
+}
+
+func NewInlineKeyboard() *InlineKeyboard {
+	return &InlineKeyboard{}
+}
+
+func (b *InlineKeyboard) Row(btns ...models.InlineKeyboardButton) *InlineKeyboard {
+	b.rows = append(b.rows, btns)
+	return b
+}
+
+func (b *InlineKeyboard) Build() models.InlineKeyboardMarkup {
+	return models.InlineKeyboardMarkup{
+		InlineKeyboard: b.rows,
+	}
+}
+
+func InlineKeyboardButton(text, data string) models.InlineKeyboardButton {
+	return models.InlineKeyboardButton{
+		Text:         text,
+		CallbackData: data,
+	}
+}
+
+func InlineKeyboardURL(text, url string) models.InlineKeyboardButton {
+	return models.InlineKeyboardButton{
+		Text: text,
+		URL:  url,
+	}
+}
+
+func InlineKeyboardWebApp(text string, webApp models.WebAppInfo) models.InlineKeyboardButton {
+	return models.InlineKeyboardButton{
+		Text:   text,
+		WebApp: &webApp,
+	}
+}
+
+func InlineKeyboardLoginURL(text string, loginURL models.LoginURL) models.InlineKeyboardButton {
+	return models.InlineKeyboardButton{
+		Text:     text,
+		LoginURL: &loginURL,
+	}
+}
+
+func InlineKeyboardSwitchInlineQuery(text, query string) models.InlineKeyboardButton {
+	return models.InlineKeyboardButton{
+		Text:              text,
+		SwitchInlineQuery: query,
+	}
+}
+
+func InlineKeyboardSwitchInlineQueryCurrentChat(text, query string) models.InlineKeyboardButton {
+	return models.InlineKeyboardButton{
+		Text:                         text,
+		SwitchInlineQueryCurrentChat: query,
+	}
+}
+
+func InlineKeyboardSwitchInlineQueryChosenChat(text string, chosenChat models.SwitchInlineQueryChosenChat) models.InlineKeyboardButton {
+	return models.InlineKeyboardButton{
+		Text:                        text,
+		SwitchInlineQueryChosenChat: &chosenChat,
+	}
+}
+
+func InlineKeyboardCopyText(text string, copyText models.CopyTextButton) models.InlineKeyboardButton {
+	return models.InlineKeyboardButton{
+		Text:     text,
+		CopyText: copyText,
+	}
+}
+
+func InlineKeyboardCallbackGame(text string, callbackGame models.CallbackGame) models.InlineKeyboardButton {
+	return models.InlineKeyboardButton{
+		Text:         text,
+		CallbackGame: &callbackGame,
+	}
+}
+
+func InlineKeyboardPay(text string) models.InlineKeyboardButton {
+	return models.InlineKeyboardButton{
+		Text: text,
+		Pay:  true,
+	}
+}


### PR DESCRIPTION
Adds a simple builder for Telegram inline keyboards to improve readability, reduce boilerplate, and provide helper functions for all button types.