### PR TITLE
fix: correct KeyboardButton.RequestUser type and use pointer for bool…

### DIFF
--- a/models/reply_markup.go
+++ b/models/reply_markup.go
@@ -61,20 +61,20 @@ type KeyboardButton struct {
 	Text              string                      `json:"text"`
 	IconCustomEmojiID string                      `json:"icon_custom_emoji_id,omitempty"`
 	Style             string                      `json:"style,omitempty"`
-	RequestUser       *KeyboardButtonRequestUsers `json:"request_user,omitempty"`
-	RequestUsers    *KeyboardButtonRequestUsers `json:"request_users,omitempty"`
-	RequestChat     *KeyboardButtonRequestChat  `json:"request_chat,omitempty"`
-	RequestContact  bool                        `json:"request_contact,omitempty"`
-	RequestLocation bool                        `json:"request_location,omitempty"`
-	RequestPoll     *KeyboardButtonPollType     `json:"request_poll,omitempty"`
-	WebApp          *WebAppInfo                 `json:"web_app,omitempty"`
+	RequestUser       *KeyboardButtonRequestUser  `json:"request_user,omitempty"`
+	RequestUsers      *KeyboardButtonRequestUsers `json:"request_users,omitempty"`
+	RequestChat       *KeyboardButtonRequestChat  `json:"request_chat,omitempty"`
+	RequestContact    bool                        `json:"request_contact,omitempty"`
+	RequestLocation   bool                        `json:"request_location,omitempty"`
+	RequestPoll       *KeyboardButtonPollType     `json:"request_poll,omitempty"`
+	WebApp            *WebAppInfo                 `json:"web_app,omitempty"`
 }
 
 // KeyboardButtonRequestUser https://core.telegram.org/bots/api#keyboardbuttonrequestuser
 type KeyboardButtonRequestUser struct {
 	RequestID     int32 `json:"request_id"`
-	UserIsBot     bool  `json:"user_is_bot,omitempty"`
-	UserIsPremium bool  `json:"user_is_premium,omitempty"`
+	UserIsBot     *bool `json:"user_is_bot,omitempty"`
+	UserIsPremium *bool `json:"user_is_premium,omitempty"`
 }
 
 // KeyboardButtonRequestUsers https://core.telegram.org/bots/api#keyboardbuttonrequestusers


### PR DESCRIPTION
## Description
This pull request fixes a bug in the `KeyboardButton` struct where the `RequestUser` field was incorrectly typed as `*KeyboardButtonRequestUsers` instead of `*KeyboardButtonRequestUser`. Additionally, the optional boolean fields `UserIsBot` and `UserIsPremium` in `KeyboardButtonRequestUser` were defined as non-pointer `bool`, which prevented the `omitempty` JSON tag from working correctly (i.e., it was impossible to distinguish between an unset field and an explicit `false` value).

## Changes
- Changed `KeyboardButton.RequestUser` type from `*KeyboardButtonRequestUsers` to `*KeyboardButtonRequestUser`.
- Changed `KeyboardButtonRequestUser.UserIsBot` from `bool` to `*bool`.
- Changed `KeyboardButtonRequestUser.UserIsPremium` from `bool` to `*bool`.