### PR TITLE
fix: always close multipart form writer to write closing boundary

### DIFF
--- a/raw_request.go
+++ b/raw_request.go
@@ -38,14 +38,13 @@ func (b *Bot) rawRequest(ctx context.Context, method string, params any, dest an
 				}
 				return
 			}
-
-			errFormClose := form.Close()
-			if errFormClose != nil {
-				if errClose := pw.CloseWithError(fmt.Errorf("error form close for method %s, %w", method, errFormClose)); errClose != nil {
-					b.errorsHandler(fmt.Errorf("error close pipe writer for method %s, %w", method, errClose))
-				}
-				return
+		}
+		errFormClose := form.Close()
+		if errFormClose != nil {
+			if errClose := pw.CloseWithError(fmt.Errorf("error form close for method %s, %w", method, errFormClose)); errClose != nil {
+				b.errorsHandler(fmt.Errorf("error close pipe writer for method %s, %w", method, errClose))
 			}
+			return
 		}
 		if errClose := pw.Close(); errClose != nil {
 			b.errorsHandler(fmt.Errorf("error close pipe writer for method %s, %w", method, errClose))


### PR DESCRIPTION
When a method has no parameters (e.g. getMe, getMyCommands), form.Close() was skipped because it was inside the params nil-check block. This left the request body empty while the Content-Type header still declared a multipart boundary, producing a malformed request.

Strict self-hosted Bot API servers reject such requests with HTTP 400 and an empty response body, causing the client to fail with:
  "error decode response body for method getMe, , unexpected end of JSON input"

Move form.Close() outside the nil-check so the closing boundary (--boundary--) is always written, regardless of whether there are any form fields.