### PR TITLE
models: add Web App BottomButton type with iconCustomEmojiId support

### DIFF
--- a/methods_test.go
+++ b/methods_test.go
@@ -432,6 +432,22 @@ func TestBot_Methods(t *testing.T) {
 		assertTrue(t, resp)
 	})
 
+	t.Run("SetChatMemberTag", func(t *testing.T) {
+		c := &httpClient{t: t, resp: `true`, reqFields: map[string]string{
+			"chat_id": "123",
+			"user_id": "456",
+			"tag":     "moderator",
+		}}
+		b := &Bot{client: c}
+		resp, err := b.SetChatMemberTag(context.Background(), &SetChatMemberTagParams{
+			ChatID: 123,
+			UserID: 456,
+			Tag:    "moderator",
+		})
+		assertNoErr(t, err)
+		assertTrue(t, resp)
+	})
+
 	t.Run("BanChatSenderChat", func(t *testing.T) {
 		c := &httpClient{t: t, resp: `true`, reqFields: map[string]string{
 			"chat_id": "123",

--- a/models/web_app.go
+++ b/models/web_app.go
@@ -15,3 +15,18 @@ type WebAppInfo struct {
 type SentWebAppMessage struct {
 	InlineMessageID string `json:"inline_message_id"`
 }
+
+// BottomButton https://core.telegram.org/bots/webapps#bottombutton
+// Describes the main or secondary button at the bottom of the Mini App (Telegram.WebApp.MainButton / SecondaryButton).
+type BottomButton struct {
+	Type              string `json:"type,omitempty"`
+	IconCustomEmojiID string `json:"iconCustomEmojiId,omitempty"`
+	Text              string `json:"text,omitempty"`
+	Color             string `json:"color,omitempty"`
+	TextColor         string `json:"textColor,omitempty"`
+	IsVisible         bool   `json:"isVisible,omitempty"`
+	IsActive          bool   `json:"isActive,omitempty"`
+	HasShineEffect    bool   `json:"hasShineEffect,omitempty"`
+	Position          string `json:"position,omitempty"`
+	IsProgressVisible bool   `json:"isProgressVisible,omitempty"`
+}

--- a/models/web_app_test.go
+++ b/models/web_app_test.go
@@ -1,0 +1,53 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestBottomButtonJSON(t *testing.T) {
+	src := `{"type":"main","iconCustomEmojiId":"123456789","text":"Continue","color":"#aabbcc","textColor":"#112233","isVisible":true,"isActive":true,"hasShineEffect":true,"position":"left","isProgressVisible":false}`
+
+	var b BottomButton
+	if err := json.Unmarshal([]byte(src), &b); err != nil {
+		t.Fatal(err)
+	}
+
+	if b.Type != "main" {
+		t.Fatalf("Type: got %q", b.Type)
+	}
+	if b.IconCustomEmojiID != "123456789" {
+		t.Fatalf("IconCustomEmojiID: got %q", b.IconCustomEmojiID)
+	}
+	if b.Text != "Continue" {
+		t.Fatalf("Text: got %q", b.Text)
+	}
+	if b.Color != "#aabbcc" {
+		t.Fatalf("Color: got %q", b.Color)
+	}
+	if b.TextColor != "#112233" {
+		t.Fatalf("TextColor: got %q", b.TextColor)
+	}
+	if !b.IsVisible || !b.IsActive || !b.HasShineEffect {
+		t.Fatalf("bools: IsVisible=%v IsActive=%v HasShineEffect=%v", b.IsVisible, b.IsActive, b.HasShineEffect)
+	}
+	if b.Position != "left" {
+		t.Fatalf("Position: got %q", b.Position)
+	}
+	if b.IsProgressVisible {
+		t.Fatal("IsProgressVisible: want false")
+	}
+
+	enc, err := json.Marshal(&b)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var round BottomButton
+	if err := json.Unmarshal(enc, &round); err != nil {
+		t.Fatal(err)
+	}
+	if round != b {
+		t.Fatalf("round-trip mismatch: %+v vs %+v", round, b)
+	}
+}


### PR DESCRIPTION
## Summary

This PR adds support for Telegram Web Apps `BottomButton` in the models package.

### What’s included
- Added `models.BottomButton` in `models/web_app.go`
- Included all documented fields for the Web Apps object:
  - `type`
  - `iconCustomEmojiId`
  - `text`
  - `color`
  - `textColor`
  - `isVisible`
  - `isActive`
  - `hasShineEffect`
  - `position`
  - `isProgressVisible`
- Added `models/web_app_test.go` with `TestBottomButtonJSON` to verify JSON unmarshal/marshal behavior and round-trip consistency

## Why

Telegram Bot/Web App updates introduced `iconCustomEmojiId` for `BottomButton`.  
This model makes it easier for users who integrate Mini App payloads in Go to parse and serialize button state with correct field names.

## Test plan

- [x] `go test ./models/ -run TestBottomButtonJSON`
- [x] `go test ./...`