### PR TITLE
fix: build request body up-front so http2 retry works on GOAWAY

### DIFF
--- a/raw_request.go
+++ b/raw_request.go
@@ -25,32 +25,37 @@ type apiResponse struct {
 	} `json:"parameters,omitempty"`
 }
 
+// rawRequest sends one Telegram Bot API call as a multipart/form-data POST.
+//
+// The body is built into a bytes.Buffer up front, then handed to
+// http.NewRequestWithContext as a *bytes.Reader. That lets net/http
+// auto-populate Request.GetBody and Request.ContentLength, which the
+// http2.Transport needs in order to retry the request when Telegram's
+// server sends a GOAWAY frame mid-flight (a routine part of HTTP/2
+// connection draining). The earlier io.Pipe-based body could not be
+// replayed, so every POST issued on a draining connection failed with
+// "cannot retry err [http2: ...] after Request.Body was written;
+// define Request.GetBody to avoid this error". Long-poll getUpdates
+// (a GET, no body) was unaffected, so a bot would keep receiving
+// updates while silently failing every reply.
+//
+// Trade-off: the entire request body is held in memory until the
+// request is sent. For the vast majority of methods (sendMessage,
+// editMessageText, callback answers, …) the body is a few KB. For
+// file uploads the body is bounded by Telegram's bot-API per-request
+// limit (~50 MB) and only held for the duration of the upload.
 func (b *Bot) rawRequest(ctx context.Context, method string, params any, dest any) error {
-	pr, pw := io.Pipe()
-	form := multipart.NewWriter(pw)
+	var bodyBuf bytes.Buffer
+	form := multipart.NewWriter(&bodyBuf)
 
-	go func() {
-		if params != nil && !reflect.ValueOf(params).IsNil() {
-			_, errFormData := buildRequestForm(form, params)
-			if errFormData != nil {
-				if errClose := pw.CloseWithError(fmt.Errorf("error build request form for method %s, %w", method, errFormData)); errClose != nil {
-					b.errorsHandler(fmt.Errorf("error close pipe writer for method %s, %w", method, errClose))
-				}
-				return
-			}
-
-			errFormClose := form.Close()
-			if errFormClose != nil {
-				if errClose := pw.CloseWithError(fmt.Errorf("error form close for method %s, %w", method, errFormClose)); errClose != nil {
-					b.errorsHandler(fmt.Errorf("error close pipe writer for method %s, %w", method, errClose))
-				}
-				return
-			}
+	if params != nil && !reflect.ValueOf(params).IsNil() {
+		if _, errFormData := buildRequestForm(form, params); errFormData != nil {
+			return fmt.Errorf("error build request form for method %s, %w", method, errFormData)
 		}
-		if errClose := pw.Close(); errClose != nil {
-			b.errorsHandler(fmt.Errorf("error close pipe writer for method %s, %w", method, errClose))
+		if errFormClose := form.Close(); errFormClose != nil {
+			return fmt.Errorf("error form close for method %s, %w", method, errFormClose)
 		}
-	}()
+	}
 
 	u := b.url + "/bot" + b.token + "/"
 	if b.testEnvironment {
@@ -63,7 +68,7 @@ func (b *Bot) rawRequest(ctx context.Context, method string, params any, dest an
 		b.debugHandler("request url: %s, payload: %s", strings.Replace(u, b.token, "***", 1), requestDebugData)
 	}
 
-	req, errRequest := http.NewRequestWithContext(ctx, http.MethodPost, u, pr)
+	req, errRequest := http.NewRequestWithContext(ctx, http.MethodPost, u, bytes.NewReader(bodyBuf.Bytes()))
 	if errRequest != nil {
 		return fmt.Errorf("error create request for method %s, %w", method, errRequest)
 	}
@@ -72,9 +77,6 @@ func (b *Bot) rawRequest(ctx context.Context, method string, params any, dest an
 
 	resp, errDo := b.client.Do(req)
 	if errDo != nil {
-		if errClose := pr.CloseWithError(errDo); errClose != nil {
-			b.errorsHandler(fmt.Errorf("error close pipe reader for method %s, %w", method, errClose))
-		}
 		var netErr *url.Error
 		if errors.As(errDo, &netErr) {
 			netErr.URL = strings.Replace(netErr.URL, b.token, "***", -1)

--- a/raw_request_test.go
+++ b/raw_request_test.go
@@ -1,6 +1,7 @@
 package bot
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"net/http"
@@ -10,10 +11,12 @@ import (
 
 type clientMock struct {
 	requestURI string
+	gotReq     *http.Request
 }
 
 func (c *clientMock) Do(req *http.Request) (*http.Response, error) {
 	c.requestURI = req.URL.RequestURI()
+	c.gotReq = req
 	resp := http.Response{
 		StatusCode: 200,
 		Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
@@ -53,5 +56,82 @@ func Test_rawRequest_url_testEnv(t *testing.T) {
 
 	if cm.requestURI != "/botXXX/test/foo" {
 		t.Fatalf("unexpected requestURI: %s", cm.requestURI)
+	}
+}
+
+// Test_rawRequest_setsGetBody verifies that the outgoing *http.Request
+// is replayable: it has a non-nil GetBody and a known ContentLength,
+// and GetBody returns bytes identical to the request body. This is
+// what http2.Transport relies on when it has to retry a POST after the
+// server sends a GOAWAY frame mid-flight — without these set, the
+// retry returns "cannot retry err [http2: ... GOAWAY] after
+// Request.Body was written; define Request.GetBody to avoid this
+// error" and every Telegram POST issued on a draining HTTP/2
+// connection fails (long-poll getUpdates is GET-with-no-body, so it
+// keeps working — the bot keeps receiving updates while silently
+// failing every reply).
+func Test_rawRequest_setsGetBody(t *testing.T) {
+	cm := &clientMock{}
+	b := &Bot{token: "XXX", client: cm}
+
+	err := b.rawRequest(context.Background(), "sendMessage", &SendMessageParams{
+		ChatID: 123,
+		Text:   "hello",
+	}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	req := cm.gotReq
+	if req == nil {
+		t.Fatal("clientMock didn't observe a request")
+	}
+	if req.GetBody == nil {
+		t.Fatal("Request.GetBody is nil — http2.Transport cannot retry on GOAWAY")
+	}
+	if req.ContentLength <= 0 {
+		t.Fatalf("Request.ContentLength is %d, expected > 0", req.ContentLength)
+	}
+
+	original, err := io.ReadAll(req.Body)
+	if err != nil {
+		t.Fatalf("read original body: %v", err)
+	}
+	if int64(len(original)) != req.ContentLength {
+		t.Fatalf("body length %d != ContentLength %d", len(original), req.ContentLength)
+	}
+
+	// Two GetBody calls must each return the full body — this is what
+	// http2.Transport does on retry, and it can be invoked more than
+	// once if a connection is dropped multiple times in quick succession.
+	for i := 0; i < 2; i++ {
+		rc, err := req.GetBody()
+		if err != nil {
+			t.Fatalf("GetBody call %d returned error: %v", i, err)
+		}
+		replay, err := io.ReadAll(rc)
+		if err != nil {
+			t.Fatalf("read replayed body call %d: %v", i, err)
+		}
+		if err := rc.Close(); err != nil {
+			t.Fatalf("close replayed body call %d: %v", i, err)
+		}
+		if !bytes.Equal(original, replay) {
+			t.Fatalf("replayed body call %d differs from original (lens %d vs %d)",
+				i, len(replay), len(original))
+		}
+	}
+
+	// The body should also contain the expected multipart fields,
+	// proving GetBody isn't just returning empty bytes that happen
+	// to match an empty original.
+	if !bytes.Contains(original, []byte(`name="chat_id"`)) {
+		t.Errorf("body missing chat_id field")
+	}
+	if !bytes.Contains(original, []byte(`name="text"`)) {
+		t.Errorf("body missing text field")
+	}
+	if !bytes.Contains(original, []byte("hello")) {
+		t.Errorf("body missing text value")
 	}
 }


### PR DESCRIPTION
## Problem

`rawRequest` streams the multipart request body through an `io.Pipe`. Pipe readers aren't replayable, so `http.NewRequestWithContext` cannot derive `Request.GetBody`, and `http2.Transport` therefore has no way to retry a POST when Telegram's server sends a GOAWAY frame mid-flight.

GOAWAY is a routine part of HTTP/2 connection draining — Telegram emits it during normal load-balancer reassignment / server rotation. Whenever it arrives between the time `client.Do` writes the request line and headers and the time it would receive the response, every in-flight POST on that connection fails with:

```
http2: Transport: cannot retry err [http2: Transport received Server's graceful shutdown GOAWAY]
after Request.Body was written; define Request.GetBody to avoid this error
```

Long-poll `getUpdates` is a GET (no body), so it isn't affected — net/http retries it transparently. The result is a bot that **keeps receiving updates** but **silently fails every `sendMessage` / `editMessageText` / `answerCallbackQuery`** for as long as the bad connection is reused. In one production deployment this manifested as the bot going completely mute for ~36 hours after Telegram rotated a server behind it; the journal showed the GOAWAY error fanning out across every outbound call simultaneously while `getUpdates` continued uninterrupted.

This affects every user of the library who reaches Telegram over HTTP/2 (i.e. nearly everyone — Go's default transport negotiates h2 via ALPN). The current workaround is to disable HTTP/2 client-side by setting `Transport.TLSNextProto` to an empty map, which forces HTTP/1.1 keep-alive and avoids the GOAWAY-retry trap entirely.

## Fix

Build the multipart body into a `bytes.Buffer` and pass `bytes.NewReader(buf.Bytes())` to `NewRequestWithContext`. `net/http` then auto-populates `Request.GetBody` and `Request.ContentLength` for `*bytes.Reader`, and `http2.Transport` retries transparently on GOAWAY.

```go
var bodyBuf bytes.Buffer
form := multipart.NewWriter(&bodyBuf)

if params != nil && !reflect.ValueOf(params).IsNil() {
    if _, err := buildRequestForm(form, params); err != nil { return … }
    if err := form.Close(); err != nil { return … }
}

req, _ := http.NewRequestWithContext(ctx, http.MethodPost, u, bytes.NewReader(bodyBuf.Bytes()))
```

The goroutine that wrote into the pipe is gone, and so is the error-handling that closed it on partial failures. Both became unnecessary once the body is materialised before `client.Do` is called.

## Trade-off

The entire request body is held in memory until the request is sent. For the vast majority of methods (`sendMessage`, `editMessageText`, callback answers, …) the body is a few KB. For file uploads the body is bounded by Telegram's bot-API per-request limit (~50 MB) and only held transiently — comparable to the OS socket buffer the streaming version would queue anyway, and small enough to be a non-issue on any modern host. If a future user needs zero-copy streaming for high-volume large uploads, the seam to reintroduce a streaming path is clear (branch on whether `params` contains an upload), but I'd argue the current behaviour was a strict bug for everyone else and shouldn't be preserved by default.

## Test

`Test_rawRequest_setsGetBody` builds a `sendMessage` request, captures the resulting `*http.Request`, and asserts:

- `req.GetBody != nil` (precondition for h2 retry).
- `req.ContentLength > 0` and matches the body length.
- Two consecutive `req.GetBody()` calls each return bytes identical to `req.Body`.
- The body contains the expected multipart fields (`name="chat_id"`, `name="text"`, the literal text value).

That covers the precise contract `http2.Transport` relies on; the actual retry-on-GOAWAY logic is exercised by net/http's own tests and doesn't need to be re-tested here.

`go test ./...`, `go test -race`, and `go vet ./...` all clean.

## Reproduction

```go
// Minimal repro — runs against a real Telegram bot.
// Without this PR, every send fails after the first GOAWAY.
ctx := context.Background()
b, _ := bot.New(token)
for i := 0; i < 1000; i++ {
    _, err := b.SendMessage(ctx, &bot.SendMessageParams{ChatID: chatID, Text: "ping"})
    if err != nil {
        log.Printf("send %d: %v", i, err)
    }
    time.Sleep(time.Second)
}
```

Run for long enough that Telegram cycles a connection (typically minutes to hours depending on which datacenter you hit). On `main` you'll eventually see the `cannot retry err [http2: ... GOAWAY]` error and every subsequent send on that connection fails. With this patch, `client.Do` retries silently and the loop keeps going.