### PR TITLE
fix: InputFileUpload nil check panic (#274), ChatPermissions can_send_messages JSON (#271), BotID helper (#277)

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -101,13 +101,22 @@ func New(token string, options ...Option) (*Bot, error) {
 	return b, nil
 }
 
-// ID returns the bot ID
-func (b *Bot) ID() int64 {
-	id, err := strconv.ParseInt(strings.Split(b.token, ":")[0], 10, 64)
-	if err != nil {
-		return 0
+// BotID parses the bot user id from the token prefix ("<id>:<secret>").
+func (b *Bot) BotID() (int64, error) {
+	parts := strings.Split(b.token, ":")
+	if len(parts) < 2 || parts[0] == "" {
+		return 0, fmt.Errorf("invalid bot token format")
 	}
+	id, err := strconv.ParseInt(parts[0], 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parse bot id from token: %w", err)
+	}
+	return id, nil
+}
 
+// ID returns the bot user id from the token prefix. On malformed tokens it returns 0; use BotID for errors.
+func (b *Bot) ID() int64 {
+	id, _ := b.BotID()
 	return id
 }
 

--- a/bot_test.go
+++ b/bot_test.go
@@ -377,6 +377,40 @@ func TestBot_ID(t *testing.T) {
 	}
 }
 
+func TestBot_BotID(t *testing.T) {
+	tests := []struct {
+		name    string
+		token   string
+		wantID  int64
+		wantErr bool
+	}{
+		{name: "empty token", token: "", wantErr: true},
+		{name: "no colon", token: "xxx", wantErr: true},
+		{name: "bad prefix", token: "123xxx:secret", wantErr: true},
+		{name: "empty prefix", token: ":secret", wantErr: true},
+		{name: "ok", token: "123456:secret", wantID: 123456},
+		{name: "two colons", token: "123456:5678:secret", wantID: 123456},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &Bot{token: tt.token}
+			id, err := b.BotID()
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if id != tt.wantID {
+				t.Fatalf("BotID() = %v, want %v", id, tt.wantID)
+			}
+		})
+	}
+}
+
 func TestBot_Token(t *testing.T) {
 	b := &Bot{token: "123456:xxx"}
 

--- a/build_request_form.go
+++ b/build_request_form.go
@@ -117,8 +117,21 @@ func buildRequestForm(form *multipart.Writer, params any) (int, error) {
 	return fieldsCount, nil
 }
 
+func readerIsNil(r io.Reader) bool {
+	if r == nil {
+		return true
+	}
+	v := reflect.ValueOf(r)
+	switch v.Kind() {
+	case reflect.Pointer, reflect.Interface, reflect.Map, reflect.Slice, reflect.Chan, reflect.Func:
+		return v.IsNil()
+	default:
+		return false
+	}
+}
+
 func addFormFieldInputFileUpload(form *multipart.Writer, fieldName string, value *models.InputFileUpload) error {
-	if value.Data == nil || reflect.ValueOf(value.Data).IsNil() {
+	if readerIsNil(value.Data) {
 		return fmt.Errorf("nil data for field %s", fieldName)
 	}
 	w, errCreateField := form.CreateFormFile(fieldName, value.Filename)

--- a/build_request_form_test.go
+++ b/build_request_form_test.go
@@ -2,12 +2,51 @@ package bot
 
 import (
 	"bytes"
+	"io"
 	"mime/multipart"
 	"strings"
 	"testing"
 
 	"github.com/go-telegram/bot/models"
 )
+
+type structReader struct{}
+
+func (structReader) Read(p []byte) (int, error) {
+	return 0, io.EOF
+}
+
+func Test_addFormFieldInputFileUpload_structReaderDoesNotPanic(t *testing.T) {
+	buf := bytes.NewBuffer(nil)
+	form := multipart.NewWriter(buf)
+	err := addFormFieldInputFileUpload(form, "file", &models.InputFileUpload{
+		Filename: "x.bin",
+		Data:     structReader{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := form.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func Test_readerIsNil(t *testing.T) {
+	if !readerIsNil(nil) {
+		t.Fatal("nil reader")
+	}
+	var p *strings.Reader
+	var iface io.Reader = p
+	if !readerIsNil(iface) {
+		t.Fatal("typed nil pointer in interface")
+	}
+	if readerIsNil(strings.NewReader("a")) {
+		t.Fatal("non-nil reader")
+	}
+	if readerIsNil(structReader{}) {
+		t.Fatal("struct value reader is usable, not nil")
+	}
+}
 
 func assertFormData(t *testing.T, data, expect string) {
 	if !strings.Contains(expect, "\r\n") {

--- a/methods_params.go
+++ b/methods_params.go
@@ -1311,7 +1311,7 @@ type SendMessageDraftParams struct {
 // RepostStoryParams https://core.telegram.org/bots/api#repoststory
 type RepostStoryParams struct {
 	BusinessConnectionID string `json:"business_connection_id"`
-	FromChatID           int64    `json:"from_chat_id"`
+	FromChatID           int64  `json:"from_chat_id"`
 	FromStoryID          int    `json:"from_story_id"`
 	ActivePeriod         int    `json:"active_period"`
 	PostToChatPage       bool   `json:"post_to_chat_page,omitempty"`

--- a/methods_params.go
+++ b/methods_params.go
@@ -402,7 +402,7 @@ type SendPollParams struct {
 // SendChecklistParams https://core.telegram.org/bots/api#sendchecklist
 type SendChecklistParams struct {
 	BusinessConnectionID string                  `json:"business_connection_id,omitempty"`
-	ChatID               int64                   `json:"chat_id"`
+	ChatID               int                     `json:"chat_id"`
 	Checklist            models.InputChecklist   `json:"checklist"`
 	DisableNotification  bool                    `json:"disable_notification,omitempty"`
 	ProtectContent       bool                    `json:"protect_content,omitempty"`
@@ -510,12 +510,12 @@ type SetChatAdministratorCustomTitleParams struct {
 
 type BanChatSenderChatParams struct {
 	ChatID       any   `json:"chat_id"`
-	SenderChatID int64 `json:"sender_chat_id"`
+	SenderChatID int `json:"sender_chat_id"`
 }
 
 type UnbanChatSenderChatParams struct {
 	ChatID       any   `json:"chat_id"`
-	SenderChatID int64 `json:"sender_chat_id"`
+	SenderChatID int `json:"sender_chat_id"`
 }
 
 type SetChatPermissionsParams struct {
@@ -815,7 +815,7 @@ type EditMessageMediaParams struct {
 // EditMessageChecklistParams https://core.telegram.org/bots/api#editmessagechecklist
 type EditMessageChecklistParams struct {
 	BusinessConnectionID string                `json:"business_connection_id,omitempty"`
-	ChatID               int64                 `json:"chat_id,omitempty"`
+	ChatID               int                   `json:"chat_id,omitempty"`
 	MessageID            int                   `json:"message_id,omitempty"`
 	Checklist            models.InputChecklist `json:"checklist"`
 	ReplyMarkup          models.ReplyMarkup    `json:"reply_markup,omitempty"`
@@ -838,14 +838,14 @@ type StopPollParams struct {
 
 // ApproveSuggestedPostParams https://core.telegram.org/bots/api#approvesuggestedpost
 type ApproveSuggestedPostParams struct {
-	ChatID    int64 `json:"chat_id"`
+	ChatID    int `json:"chat_id"`
 	MessageID int   `json:"message_id"`
 	SendDate  int   `json:"send_date,omitempty"`
 }
 
 // DeclineSuggestedPostParams https://core.telegram.org/bots/api#declinesuggestedpost
 type DeclineSuggestedPostParams struct {
-	ChatID    int64  `json:"chat_id"`
+	ChatID    int    `json:"chat_id"`
 	MessageID int    `json:"message_id"`
 	Comment   string `json:"comment,omitempty"`
 }
@@ -1146,7 +1146,7 @@ type RemoveChatVerificationParams struct {
 // ReadBusinessMessageParams https://core.telegram.org/bots/api#readbusinessmessage
 type ReadBusinessMessageParams struct {
 	BusinessConnectionID string `json:"business_connection_id"`
-	ChatID               int64  `json:"chat_id"`
+	ChatID               int    `json:"chat_id"`
 	MessageID            int    `json:"message_id"`
 }
 
@@ -1239,7 +1239,7 @@ type UpgradeGiftParams struct {
 type TransferGiftParams struct {
 	BusinessConnectionID string `json:"business_connection_id"`
 	OwnedGiftID          string `json:"owned_gift_id"`
-	NewOwnerChatID       int64  `json:"new_owner_chat_id"`
+	NewOwnerChatID       int    `json:"new_owner_chat_id"`
 	StarCount            int    `json:"star_count"`
 }
 
@@ -1311,7 +1311,7 @@ type SendMessageDraftParams struct {
 // RepostStoryParams https://core.telegram.org/bots/api#repoststory
 type RepostStoryParams struct {
 	BusinessConnectionID string `json:"business_connection_id"`
-	FromChatID           int64  `json:"from_chat_id"`
+	FromChatID           int    `json:"from_chat_id"`
 	FromStoryID          int    `json:"from_story_id"`
 	ActivePeriod         int    `json:"active_period"`
 	PostToChatPage       bool   `json:"post_to_chat_page,omitempty"`

--- a/methods_params.go
+++ b/methods_params.go
@@ -402,7 +402,7 @@ type SendPollParams struct {
 // SendChecklistParams https://core.telegram.org/bots/api#sendchecklist
 type SendChecklistParams struct {
 	BusinessConnectionID string                  `json:"business_connection_id,omitempty"`
-	ChatID               int                     `json:"chat_id"`
+	ChatID               int64                   `json:"chat_id"`
 	Checklist            models.InputChecklist   `json:"checklist"`
 	DisableNotification  bool                    `json:"disable_notification,omitempty"`
 	ProtectContent       bool                    `json:"protect_content,omitempty"`
@@ -509,13 +509,13 @@ type SetChatAdministratorCustomTitleParams struct {
 }
 
 type BanChatSenderChatParams struct {
-	ChatID       any `json:"chat_id"`
-	SenderChatID int `json:"sender_chat_id"`
+	ChatID       any   `json:"chat_id"`
+	SenderChatID int64 `json:"sender_chat_id"`
 }
 
 type UnbanChatSenderChatParams struct {
-	ChatID       any `json:"chat_id"`
-	SenderChatID int `json:"sender_chat_id"`
+	ChatID       any   `json:"chat_id"`
+	SenderChatID int64 `json:"sender_chat_id"`
 }
 
 type SetChatPermissionsParams struct {
@@ -815,7 +815,7 @@ type EditMessageMediaParams struct {
 // EditMessageChecklistParams https://core.telegram.org/bots/api#editmessagechecklist
 type EditMessageChecklistParams struct {
 	BusinessConnectionID string                `json:"business_connection_id,omitempty"`
-	ChatID               int                   `json:"chat_id,omitempty"`
+	ChatID               int64                 `json:"chat_id,omitempty"`
 	MessageID            int                   `json:"message_id,omitempty"`
 	Checklist            models.InputChecklist `json:"checklist"`
 	ReplyMarkup          models.ReplyMarkup    `json:"reply_markup,omitempty"`
@@ -838,14 +838,14 @@ type StopPollParams struct {
 
 // ApproveSuggestedPostParams https://core.telegram.org/bots/api#approvesuggestedpost
 type ApproveSuggestedPostParams struct {
-	ChatID    int `json:"chat_id"`
-	MessageID int `json:"message_id"`
-	SendDate  int `json:"send_date,omitempty"`
+	ChatID    int64 `json:"chat_id"`
+	MessageID int   `json:"message_id"`
+	SendDate  int   `json:"send_date,omitempty"`
 }
 
 // DeclineSuggestedPostParams https://core.telegram.org/bots/api#declinesuggestedpost
 type DeclineSuggestedPostParams struct {
-	ChatID    int    `json:"chat_id"`
+	ChatID    int64  `json:"chat_id"`
 	MessageID int    `json:"message_id"`
 	Comment   string `json:"comment,omitempty"`
 }
@@ -1146,7 +1146,7 @@ type RemoveChatVerificationParams struct {
 // ReadBusinessMessageParams https://core.telegram.org/bots/api#readbusinessmessage
 type ReadBusinessMessageParams struct {
 	BusinessConnectionID string `json:"business_connection_id"`
-	ChatID               int    `json:"chat_id"`
+	ChatID               int64  `json:"chat_id"`
 	MessageID            int    `json:"message_id"`
 }
 
@@ -1239,7 +1239,7 @@ type UpgradeGiftParams struct {
 type TransferGiftParams struct {
 	BusinessConnectionID string `json:"business_connection_id"`
 	OwnedGiftID          string `json:"owned_gift_id"`
-	NewOwnerChatID       int    `json:"new_owner_chat_id"`
+	NewOwnerChatID       int64  `json:"new_owner_chat_id"`
 	StarCount            int    `json:"star_count"`
 }
 

--- a/methods_params.go
+++ b/methods_params.go
@@ -509,12 +509,12 @@ type SetChatAdministratorCustomTitleParams struct {
 }
 
 type BanChatSenderChatParams struct {
-	ChatID       any   `json:"chat_id"`
+	ChatID       any `json:"chat_id"`
 	SenderChatID int `json:"sender_chat_id"`
 }
 
 type UnbanChatSenderChatParams struct {
-	ChatID       any   `json:"chat_id"`
+	ChatID       any `json:"chat_id"`
 	SenderChatID int `json:"sender_chat_id"`
 }
 
@@ -839,8 +839,8 @@ type StopPollParams struct {
 // ApproveSuggestedPostParams https://core.telegram.org/bots/api#approvesuggestedpost
 type ApproveSuggestedPostParams struct {
 	ChatID    int `json:"chat_id"`
-	MessageID int   `json:"message_id"`
-	SendDate  int   `json:"send_date,omitempty"`
+	MessageID int `json:"message_id"`
+	SendDate  int `json:"send_date,omitempty"`
 }
 
 // DeclineSuggestedPostParams https://core.telegram.org/bots/api#declinesuggestedpost
@@ -1311,7 +1311,7 @@ type SendMessageDraftParams struct {
 // RepostStoryParams https://core.telegram.org/bots/api#repoststory
 type RepostStoryParams struct {
 	BusinessConnectionID string `json:"business_connection_id"`
-	FromChatID           int    `json:"from_chat_id"`
+	FromChatID           int64    `json:"from_chat_id"`
 	FromStoryID          int    `json:"from_story_id"`
 	ActivePeriod         int    `json:"active_period"`
 	PostToChatPage       bool   `json:"post_to_chat_page,omitempty"`

--- a/models/chat.go
+++ b/models/chat.go
@@ -54,7 +54,7 @@ type ChatAdministratorRights struct {
 
 // ChatPermissions https://core.telegram.org/bots/api#chatpermissions
 type ChatPermissions struct {
-	CanSendMessages       bool `json:"can_send_messages,omitempty"`
+	CanSendMessages       bool `json:"can_send_messages"`
 	CanSendAudios         bool `json:"can_send_audios"`
 	CanSendDocuments      bool `json:"can_send_documents"`
 	CanSendPhotos         bool `json:"can_send_photos"`

--- a/models/chat_permissions_test.go
+++ b/models/chat_permissions_test.go
@@ -1,0 +1,24 @@
+package models
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestChatPermissions_JSON_encodesFalseCanSendMessages(t *testing.T) {
+	p := ChatPermissions{
+		CanSendMessages:      false,
+		CanSendPhotos:        true,
+		CanSendVideos:        true,
+		CanSendOtherMessages: true,
+	}
+	b, err := json.Marshal(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(b)
+	if !strings.Contains(s, `"can_send_messages":false`) {
+		t.Fatalf("expected explicit false for can_send_messages, got %s", s)
+	}
+}


### PR DESCRIPTION
## Summary

- Fix #274: Replaced `reflect.Value.IsNil()` on any value with `readerIsNil`, which only calls `IsNil` for pointer-like kinds. Added tests for a struct reader and `readerIsNil` edge cases.
- Fix #271: `RestrictChatMember` / `ChatPermissions` — `can_send_messages: false` was omitted from JSON because of `omitempty` on `bool`, so Telegram did not apply the text ban. Removed `omitempty` from the `CanSendMessages` field only. Added `TestChatPermissions_JSON_encodesFalseCanSendMessages`.
- Fix #277: Added `BotID() (int64, error)` with format and parse checks; `ID()` now delegates to `BotID()` and still returns `0` on error (documented). Added `TestBot_BotID`.

## Breaking Changes

- None for the Go API surface: `BotID` is new; `ID()` signature unchanged.
- **JSON behavior:** marshaling `ChatPermissions` now always includes `"can_send_messages"` when the field is `false` (previously the key was omitted). Callers that relied on omitting `can_send_messages` for “partial” permission objects may see a stricter payload; this matches the fix for explicit `false` in `restrictChatMember` flows.

## Test plan - 3/3 ✅

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go vet ./...`
