### PR TITLE
feat: support Bot API 10.1 (Rich Messages)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v1.22.0
+
+- Support Bot API 10.1 (June 11, 2026 update) — Rich Messages:
+  - Methods: `sendRichMessage`, `sendRichMessageDraft`, and a `rich_message`
+    parameter on `editMessageText`.
+  - Send types: `InputRichMessage` (carries `<tg-thinking>` for reasoning),
+    `InputRichMessageContent`.
+  - Receive types: `RichMessage` (+ `rich_message` field on `Message`), the
+    `RichBlock` union (21 blocks incl. `RichBlockThinking`) and the polymorphic
+    `RichText` union (string | array | 25 tagged variants), plus `RichBlockCaption`,
+    `RichBlockListItem`, `RichBlockTableCell`.
+
 ## v1.21.0 (2026-05-22)
 
 - Support Bot API 9.6 & 10.0, multipart fixes — closes #279 #280, fixes #273 #274 #271 #277 (#281)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 > [Telegram Group](https://t.me/gotelegrambotui)
 
-> Supports Bot API version: [10.0](https://core.telegram.org/bots/api#may-8-2026) from May 8, 2026
+> Supports Bot API version: [10.1](https://core.telegram.org/bots/api#june-11-2026) from June 11, 2026
 
 It's a Go zero-dependencies telegram bot framework
 

--- a/methods.go
+++ b/methods.go
@@ -1114,6 +1114,20 @@ func (b *Bot) SendMessageDraft(ctx context.Context, params *SendMessageDraftPara
 	return result, err
 }
 
+// SendRichMessage https://core.telegram.org/bots/api#sendrichmessage
+func (b *Bot) SendRichMessage(ctx context.Context, params *SendRichMessageParams) (*models.Message, error) {
+	result := &models.Message{}
+	err := b.rawRequest(ctx, "sendRichMessage", params, result)
+	return result, err
+}
+
+// SendRichMessageDraft https://core.telegram.org/bots/api#sendrichmessagedraft
+func (b *Bot) SendRichMessageDraft(ctx context.Context, params *SendRichMessageDraftParams) (bool, error) {
+	var result bool
+	err := b.rawRequest(ctx, "sendRichMessageDraft", params, &result)
+	return result, err
+}
+
 // RepostStory https://core.telegram.org/bots/api#repoststory
 func (b *Bot) RepostStory(ctx context.Context, params *RepostStoryParams) (*models.Story, error) {
 	result := &models.Story{}

--- a/methods_params.go
+++ b/methods_params.go
@@ -799,6 +799,7 @@ type EditMessageTextParams struct {
 	ParseMode            models.ParseMode           `json:"parse_mode,omitempty"`
 	Entities             []models.MessageEntity     `json:"entities,omitempty"`
 	LinkPreviewOptions   *models.LinkPreviewOptions `json:"link_preview_options,omitempty"`
+	RichMessage          *models.InputRichMessage   `json:"rich_message,omitempty"`
 	ReplyMarkup          models.ReplyMarkup         `json:"reply_markup,omitempty"`
 }
 
@@ -1318,6 +1319,30 @@ type SendMessageDraftParams struct {
 	Text                 string                 `json:"text"`
 	ParseMode            models.ParseMode       `json:"parse_mode,omitempty"`
 	Entities             []models.MessageEntity `json:"entities,omitempty"`
+}
+
+// SendRichMessageParams https://core.telegram.org/bots/api#sendrichmessage
+type SendRichMessageParams struct {
+	BusinessConnectionID    string                          `json:"business_connection_id,omitempty"`
+	ChatID                  any                             `json:"chat_id"`
+	MessageThreadID         int                             `json:"message_thread_id,omitempty"`
+	DirectMessagesTopicID   int                             `json:"direct_messages_topic_id,omitempty"`
+	RichMessage             models.InputRichMessage         `json:"rich_message"`
+	DisableNotification     bool                            `json:"disable_notification,omitempty"`
+	ProtectContent          bool                            `json:"protect_content,omitempty"`
+	AllowPaidBroadcast      bool                            `json:"allow_paid_broadcast,omitempty"`
+	MessageEffectID         string                          `json:"message_effect_id,omitempty"`
+	SuggestedPostParameters *models.SuggestedPostParameters `json:"suggested_post_parameters,omitempty"`
+	ReplyParameters         *models.ReplyParameters         `json:"reply_parameters,omitempty"`
+	ReplyMarkup             models.ReplyMarkup              `json:"reply_markup,omitempty"`
+}
+
+// SendRichMessageDraftParams https://core.telegram.org/bots/api#sendrichmessagedraft
+type SendRichMessageDraftParams struct {
+	ChatID          int64                   `json:"chat_id"`
+	MessageThreadID int                     `json:"message_thread_id,omitempty"`
+	DraftID         int                     `json:"draft_id"`
+	RichMessage     models.InputRichMessage `json:"rich_message"`
 }
 
 // RepostStoryParams https://core.telegram.org/bots/api#repoststory

--- a/methods_test.go
+++ b/methods_test.go
@@ -1389,3 +1389,37 @@ func TestBot_Methods(t *testing.T) {
 	})
 
 }
+
+func TestBot_RichMessageMethods(t *testing.T) {
+	t.Parallel()
+
+	t.Run("SendRichMessage", func(t *testing.T) {
+		c := &httpClient{t: t, resp: `{"message_id":7,"date":1,"chat":{"id":123,"type":"private"}}`, reqFields: map[string]string{
+			"chat_id":      "123",
+			"rich_message": `{"html":"hello"}`,
+		}}
+		b := &Bot{client: c}
+		resp, err := b.SendRichMessage(context.Background(), &SendRichMessageParams{
+			ChatID:      123,
+			RichMessage: models.InputRichMessage{HTML: "hello"},
+		})
+		assertNoErr(t, err)
+		assertEqualInt(t, 7, resp.ID)
+	})
+
+	t.Run("SendRichMessageDraft", func(t *testing.T) {
+		c := &httpClient{t: t, resp: `true`, reqFields: map[string]string{
+			"chat_id":      "123",
+			"draft_id":     "1",
+			"rich_message": `{"html":"hello"}`,
+		}}
+		b := &Bot{client: c}
+		resp, err := b.SendRichMessageDraft(context.Background(), &SendRichMessageDraftParams{
+			ChatID:      123,
+			DraftID:     1,
+			RichMessage: models.InputRichMessage{HTML: "hello"},
+		})
+		assertNoErr(t, err)
+		assertTrue(t, resp)
+	})
+}

--- a/models/message.go
+++ b/models/message.go
@@ -109,6 +109,7 @@ type Message struct {
 	PaidStarCount                 int                            `json:"paid_star_count,omitempty"`
 	Text                          string                         `json:"text,omitempty"`
 	Entities                      []MessageEntity                `json:"entities,omitempty"`
+	RichMessage                   *RichMessage                   `json:"rich_message,omitempty"`
 	LinkPreviewOptions            *LinkPreviewOptions            `json:"link_preview_options,omitempty"`
 	SuggestedPostInfo             *SuggestedPostInfo             `json:"suggested_post_info,omitempty"`
 	EffectID                      string                         `json:"effect_id,omitempty"`

--- a/models/rich_block.go
+++ b/models/rich_block.go
@@ -1,0 +1,384 @@
+package models
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// RichBlockType https://core.telegram.org/bots/api#richblock
+type RichBlockType string
+
+const (
+	RichBlockTypeParagraph              RichBlockType = "paragraph"
+	RichBlockTypeSectionHeading         RichBlockType = "heading"
+	RichBlockTypePreformatted           RichBlockType = "pre"
+	RichBlockTypeFooter                 RichBlockType = "footer"
+	RichBlockTypeDivider                RichBlockType = "divider"
+	RichBlockTypeMathematicalExpression RichBlockType = "mathematical_expression"
+	RichBlockTypeAnchor                 RichBlockType = "anchor"
+	RichBlockTypeList                   RichBlockType = "list"
+	RichBlockTypeBlockQuotation         RichBlockType = "blockquote"
+	RichBlockTypePullQuotation          RichBlockType = "pullquote"
+	RichBlockTypeCollage                RichBlockType = "collage"
+	RichBlockTypeSlideshow              RichBlockType = "slideshow"
+	RichBlockTypeTable                  RichBlockType = "table"
+	RichBlockTypeDetails                RichBlockType = "details"
+	RichBlockTypeMap                    RichBlockType = "map"
+	RichBlockTypeAnimation              RichBlockType = "animation"
+	RichBlockTypeAudio                  RichBlockType = "audio"
+	RichBlockTypePhoto                  RichBlockType = "photo"
+	RichBlockTypeVideo                  RichBlockType = "video"
+	RichBlockTypeVoiceNote              RichBlockType = "voice_note"
+	RichBlockTypeThinking               RichBlockType = "thinking"
+)
+
+// RichBlock https://core.telegram.org/bots/api#richblock
+//
+// RichBlock is a tagged union; Type holds the discriminator and the matching
+// variant pointer is populated.
+type RichBlock struct {
+	Type RichBlockType
+
+	RichBlockParagraph              *RichBlockParagraph
+	RichBlockSectionHeading         *RichBlockSectionHeading
+	RichBlockPreformatted           *RichBlockPreformatted
+	RichBlockFooter                 *RichBlockFooter
+	RichBlockDivider                *RichBlockDivider
+	RichBlockMathematicalExpression *RichBlockMathematicalExpression
+	RichBlockAnchor                 *RichBlockAnchor
+	RichBlockList                   *RichBlockList
+	RichBlockBlockQuotation         *RichBlockBlockQuotation
+	RichBlockPullQuotation          *RichBlockPullQuotation
+	RichBlockCollage                *RichBlockCollage
+	RichBlockSlideshow              *RichBlockSlideshow
+	RichBlockTable                  *RichBlockTable
+	RichBlockDetails                *RichBlockDetails
+	RichBlockMap                    *RichBlockMap
+	RichBlockAnimation              *RichBlockAnimation
+	RichBlockAudio                  *RichBlockAudio
+	RichBlockPhoto                  *RichBlockPhoto
+	RichBlockVideo                  *RichBlockVideo
+	RichBlockVoiceNote              *RichBlockVoiceNote
+	RichBlockThinking               *RichBlockThinking
+}
+
+// MarshalJSON implements json.Marshaler. The value receiver ensures the encoding
+// is applied even when a RichBlock is reached as a (non-pointer) struct field.
+func (rb RichBlock) MarshalJSON() ([]byte, error) {
+	switch rb.Type {
+	case RichBlockTypeParagraph:
+		rb.RichBlockParagraph.Type = RichBlockTypeParagraph
+		return json.Marshal(rb.RichBlockParagraph)
+	case RichBlockTypeSectionHeading:
+		rb.RichBlockSectionHeading.Type = RichBlockTypeSectionHeading
+		return json.Marshal(rb.RichBlockSectionHeading)
+	case RichBlockTypePreformatted:
+		rb.RichBlockPreformatted.Type = RichBlockTypePreformatted
+		return json.Marshal(rb.RichBlockPreformatted)
+	case RichBlockTypeFooter:
+		rb.RichBlockFooter.Type = RichBlockTypeFooter
+		return json.Marshal(rb.RichBlockFooter)
+	case RichBlockTypeDivider:
+		rb.RichBlockDivider.Type = RichBlockTypeDivider
+		return json.Marshal(rb.RichBlockDivider)
+	case RichBlockTypeMathematicalExpression:
+		rb.RichBlockMathematicalExpression.Type = RichBlockTypeMathematicalExpression
+		return json.Marshal(rb.RichBlockMathematicalExpression)
+	case RichBlockTypeAnchor:
+		rb.RichBlockAnchor.Type = RichBlockTypeAnchor
+		return json.Marshal(rb.RichBlockAnchor)
+	case RichBlockTypeList:
+		rb.RichBlockList.Type = RichBlockTypeList
+		return json.Marshal(rb.RichBlockList)
+	case RichBlockTypeBlockQuotation:
+		rb.RichBlockBlockQuotation.Type = RichBlockTypeBlockQuotation
+		return json.Marshal(rb.RichBlockBlockQuotation)
+	case RichBlockTypePullQuotation:
+		rb.RichBlockPullQuotation.Type = RichBlockTypePullQuotation
+		return json.Marshal(rb.RichBlockPullQuotation)
+	case RichBlockTypeCollage:
+		rb.RichBlockCollage.Type = RichBlockTypeCollage
+		return json.Marshal(rb.RichBlockCollage)
+	case RichBlockTypeSlideshow:
+		rb.RichBlockSlideshow.Type = RichBlockTypeSlideshow
+		return json.Marshal(rb.RichBlockSlideshow)
+	case RichBlockTypeTable:
+		rb.RichBlockTable.Type = RichBlockTypeTable
+		return json.Marshal(rb.RichBlockTable)
+	case RichBlockTypeDetails:
+		rb.RichBlockDetails.Type = RichBlockTypeDetails
+		return json.Marshal(rb.RichBlockDetails)
+	case RichBlockTypeMap:
+		rb.RichBlockMap.Type = RichBlockTypeMap
+		return json.Marshal(rb.RichBlockMap)
+	case RichBlockTypeAnimation:
+		rb.RichBlockAnimation.Type = RichBlockTypeAnimation
+		return json.Marshal(rb.RichBlockAnimation)
+	case RichBlockTypeAudio:
+		rb.RichBlockAudio.Type = RichBlockTypeAudio
+		return json.Marshal(rb.RichBlockAudio)
+	case RichBlockTypePhoto:
+		rb.RichBlockPhoto.Type = RichBlockTypePhoto
+		return json.Marshal(rb.RichBlockPhoto)
+	case RichBlockTypeVideo:
+		rb.RichBlockVideo.Type = RichBlockTypeVideo
+		return json.Marshal(rb.RichBlockVideo)
+	case RichBlockTypeVoiceNote:
+		rb.RichBlockVoiceNote.Type = RichBlockTypeVoiceNote
+		return json.Marshal(rb.RichBlockVoiceNote)
+	case RichBlockTypeThinking:
+		rb.RichBlockThinking.Type = RichBlockTypeThinking
+		return json.Marshal(rb.RichBlockThinking)
+	}
+
+	return nil, fmt.Errorf("unsupported RichBlock type %q", rb.Type)
+}
+
+func (rb *RichBlock) UnmarshalJSON(data []byte) error {
+	v := struct {
+		Type RichBlockType `json:"type"`
+	}{}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	switch v.Type {
+	case RichBlockTypeParagraph:
+		rb.Type = RichBlockTypeParagraph
+		rb.RichBlockParagraph = &RichBlockParagraph{}
+		return json.Unmarshal(data, rb.RichBlockParagraph)
+	case RichBlockTypeSectionHeading:
+		rb.Type = RichBlockTypeSectionHeading
+		rb.RichBlockSectionHeading = &RichBlockSectionHeading{}
+		return json.Unmarshal(data, rb.RichBlockSectionHeading)
+	case RichBlockTypePreformatted:
+		rb.Type = RichBlockTypePreformatted
+		rb.RichBlockPreformatted = &RichBlockPreformatted{}
+		return json.Unmarshal(data, rb.RichBlockPreformatted)
+	case RichBlockTypeFooter:
+		rb.Type = RichBlockTypeFooter
+		rb.RichBlockFooter = &RichBlockFooter{}
+		return json.Unmarshal(data, rb.RichBlockFooter)
+	case RichBlockTypeDivider:
+		rb.Type = RichBlockTypeDivider
+		rb.RichBlockDivider = &RichBlockDivider{}
+		return json.Unmarshal(data, rb.RichBlockDivider)
+	case RichBlockTypeMathematicalExpression:
+		rb.Type = RichBlockTypeMathematicalExpression
+		rb.RichBlockMathematicalExpression = &RichBlockMathematicalExpression{}
+		return json.Unmarshal(data, rb.RichBlockMathematicalExpression)
+	case RichBlockTypeAnchor:
+		rb.Type = RichBlockTypeAnchor
+		rb.RichBlockAnchor = &RichBlockAnchor{}
+		return json.Unmarshal(data, rb.RichBlockAnchor)
+	case RichBlockTypeList:
+		rb.Type = RichBlockTypeList
+		rb.RichBlockList = &RichBlockList{}
+		return json.Unmarshal(data, rb.RichBlockList)
+	case RichBlockTypeBlockQuotation:
+		rb.Type = RichBlockTypeBlockQuotation
+		rb.RichBlockBlockQuotation = &RichBlockBlockQuotation{}
+		return json.Unmarshal(data, rb.RichBlockBlockQuotation)
+	case RichBlockTypePullQuotation:
+		rb.Type = RichBlockTypePullQuotation
+		rb.RichBlockPullQuotation = &RichBlockPullQuotation{}
+		return json.Unmarshal(data, rb.RichBlockPullQuotation)
+	case RichBlockTypeCollage:
+		rb.Type = RichBlockTypeCollage
+		rb.RichBlockCollage = &RichBlockCollage{}
+		return json.Unmarshal(data, rb.RichBlockCollage)
+	case RichBlockTypeSlideshow:
+		rb.Type = RichBlockTypeSlideshow
+		rb.RichBlockSlideshow = &RichBlockSlideshow{}
+		return json.Unmarshal(data, rb.RichBlockSlideshow)
+	case RichBlockTypeTable:
+		rb.Type = RichBlockTypeTable
+		rb.RichBlockTable = &RichBlockTable{}
+		return json.Unmarshal(data, rb.RichBlockTable)
+	case RichBlockTypeDetails:
+		rb.Type = RichBlockTypeDetails
+		rb.RichBlockDetails = &RichBlockDetails{}
+		return json.Unmarshal(data, rb.RichBlockDetails)
+	case RichBlockTypeMap:
+		rb.Type = RichBlockTypeMap
+		rb.RichBlockMap = &RichBlockMap{}
+		return json.Unmarshal(data, rb.RichBlockMap)
+	case RichBlockTypeAnimation:
+		rb.Type = RichBlockTypeAnimation
+		rb.RichBlockAnimation = &RichBlockAnimation{}
+		return json.Unmarshal(data, rb.RichBlockAnimation)
+	case RichBlockTypeAudio:
+		rb.Type = RichBlockTypeAudio
+		rb.RichBlockAudio = &RichBlockAudio{}
+		return json.Unmarshal(data, rb.RichBlockAudio)
+	case RichBlockTypePhoto:
+		rb.Type = RichBlockTypePhoto
+		rb.RichBlockPhoto = &RichBlockPhoto{}
+		return json.Unmarshal(data, rb.RichBlockPhoto)
+	case RichBlockTypeVideo:
+		rb.Type = RichBlockTypeVideo
+		rb.RichBlockVideo = &RichBlockVideo{}
+		return json.Unmarshal(data, rb.RichBlockVideo)
+	case RichBlockTypeVoiceNote:
+		rb.Type = RichBlockTypeVoiceNote
+		rb.RichBlockVoiceNote = &RichBlockVoiceNote{}
+		return json.Unmarshal(data, rb.RichBlockVoiceNote)
+	case RichBlockTypeThinking:
+		rb.Type = RichBlockTypeThinking
+		rb.RichBlockThinking = &RichBlockThinking{}
+		return json.Unmarshal(data, rb.RichBlockThinking)
+	}
+
+	return fmt.Errorf("unsupported RichBlock type %q", v.Type)
+}
+
+// RichBlockParagraph https://core.telegram.org/bots/api#richblockparagraph
+type RichBlockParagraph struct {
+	Type RichBlockType `json:"type"`
+	Text RichText      `json:"text"`
+}
+
+// RichBlockSectionHeading https://core.telegram.org/bots/api#richblocksectionheading
+type RichBlockSectionHeading struct {
+	Type RichBlockType `json:"type"`
+	Text RichText      `json:"text"`
+	Size int           `json:"size"`
+}
+
+// RichBlockPreformatted https://core.telegram.org/bots/api#richblockpreformatted
+type RichBlockPreformatted struct {
+	Type     RichBlockType `json:"type"`
+	Text     RichText      `json:"text"`
+	Language string        `json:"language,omitempty"`
+}
+
+// RichBlockFooter https://core.telegram.org/bots/api#richblockfooter
+type RichBlockFooter struct {
+	Type RichBlockType `json:"type"`
+	Text RichText      `json:"text"`
+}
+
+// RichBlockDivider https://core.telegram.org/bots/api#richblockdivider
+type RichBlockDivider struct {
+	Type RichBlockType `json:"type"`
+}
+
+// RichBlockMathematicalExpression https://core.telegram.org/bots/api#richblockmathematicalexpression
+type RichBlockMathematicalExpression struct {
+	Type       RichBlockType `json:"type"`
+	Expression string        `json:"expression"`
+}
+
+// RichBlockAnchor https://core.telegram.org/bots/api#richblockanchor
+type RichBlockAnchor struct {
+	Type RichBlockType `json:"type"`
+	Name string        `json:"name"`
+}
+
+// RichBlockList https://core.telegram.org/bots/api#richblocklist
+type RichBlockList struct {
+	Type  RichBlockType       `json:"type"`
+	Items []RichBlockListItem `json:"items"`
+}
+
+// RichBlockBlockQuotation https://core.telegram.org/bots/api#richblockblockquotation
+type RichBlockBlockQuotation struct {
+	Type   RichBlockType `json:"type"`
+	Blocks []RichBlock   `json:"blocks"`
+	Credit *RichText     `json:"credit,omitempty"`
+}
+
+// RichBlockPullQuotation https://core.telegram.org/bots/api#richblockpullquotation
+type RichBlockPullQuotation struct {
+	Type   RichBlockType `json:"type"`
+	Text   RichText      `json:"text"`
+	Credit *RichText     `json:"credit,omitempty"`
+}
+
+// RichBlockCollage https://core.telegram.org/bots/api#richblockcollage
+type RichBlockCollage struct {
+	Type    RichBlockType     `json:"type"`
+	Blocks  []RichBlock       `json:"blocks"`
+	Caption *RichBlockCaption `json:"caption,omitempty"`
+}
+
+// RichBlockSlideshow https://core.telegram.org/bots/api#richblockslideshow
+type RichBlockSlideshow struct {
+	Type    RichBlockType     `json:"type"`
+	Blocks  []RichBlock       `json:"blocks"`
+	Caption *RichBlockCaption `json:"caption,omitempty"`
+}
+
+// RichBlockTable https://core.telegram.org/bots/api#richblocktable
+type RichBlockTable struct {
+	Type       RichBlockType          `json:"type"`
+	Cells      [][]RichBlockTableCell `json:"cells"`
+	IsBordered bool                   `json:"is_bordered,omitempty"`
+	IsStriped  bool                   `json:"is_striped,omitempty"`
+	Caption    *RichText              `json:"caption,omitempty"`
+}
+
+// RichBlockDetails https://core.telegram.org/bots/api#richblockdetails
+type RichBlockDetails struct {
+	Type    RichBlockType `json:"type"`
+	Summary RichText      `json:"summary"`
+	Blocks  []RichBlock   `json:"blocks"`
+	IsOpen  bool          `json:"is_open,omitempty"`
+}
+
+// RichBlockMap https://core.telegram.org/bots/api#richblockmap
+type RichBlockMap struct {
+	Type     RichBlockType     `json:"type"`
+	Location Location          `json:"location"`
+	Zoom     int               `json:"zoom"`
+	Width    int               `json:"width"`
+	Height   int               `json:"height"`
+	Caption  *RichBlockCaption `json:"caption,omitempty"`
+}
+
+// RichBlockAnimation https://core.telegram.org/bots/api#richblockanimation
+type RichBlockAnimation struct {
+	Type       RichBlockType     `json:"type"`
+	Animation  Animation         `json:"animation"`
+	HasSpoiler bool              `json:"has_spoiler,omitempty"`
+	Caption    *RichBlockCaption `json:"caption,omitempty"`
+}
+
+// RichBlockAudio https://core.telegram.org/bots/api#richblockaudio
+type RichBlockAudio struct {
+	Type    RichBlockType     `json:"type"`
+	Audio   Audio             `json:"audio"`
+	Caption *RichBlockCaption `json:"caption,omitempty"`
+}
+
+// RichBlockPhoto https://core.telegram.org/bots/api#richblockphoto
+type RichBlockPhoto struct {
+	Type       RichBlockType     `json:"type"`
+	Photo      []PhotoSize       `json:"photo"`
+	HasSpoiler bool              `json:"has_spoiler,omitempty"`
+	Caption    *RichBlockCaption `json:"caption,omitempty"`
+}
+
+// RichBlockVideo https://core.telegram.org/bots/api#richblockvideo
+type RichBlockVideo struct {
+	Type       RichBlockType     `json:"type"`
+	Video      Video             `json:"video"`
+	HasSpoiler bool              `json:"has_spoiler,omitempty"`
+	Caption    *RichBlockCaption `json:"caption,omitempty"`
+}
+
+// RichBlockVoiceNote https://core.telegram.org/bots/api#richblockvoicenote
+type RichBlockVoiceNote struct {
+	Type      RichBlockType     `json:"type"`
+	VoiceNote Voice             `json:"voice_note"`
+	Caption   *RichBlockCaption `json:"caption,omitempty"`
+}
+
+// RichBlockThinking https://core.telegram.org/bots/api#richblockthinking
+//
+// A block with a "Thinking..." placeholder, corresponding to the custom HTML tag
+// <tg-thinking>.
+type RichBlockThinking struct {
+	Type RichBlockType `json:"type"`
+	Text RichText      `json:"text"`
+}

--- a/models/rich_block_test.go
+++ b/models/rich_block_test.go
@@ -1,0 +1,92 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func richBlockRoundTrip(t *testing.T, src string) RichBlock {
+	t.Helper()
+
+	var rb RichBlock
+	if err := json.Unmarshal([]byte(src), &rb); err != nil {
+		t.Fatalf("unmarshal %s: %v", src, err)
+	}
+
+	out, err := json.Marshal(rb)
+	if err != nil {
+		t.Fatalf("marshal %s: %v", src, err)
+	}
+
+	if string(out) != src {
+		t.Fatalf("round-trip mismatch:\n got %s\nwant %s", out, src)
+	}
+
+	return rb
+}
+
+func TestRichBlock_Thinking(t *testing.T) {
+	rb := richBlockRoundTrip(t, `{"type":"thinking","text":"weighing the options"}`)
+	if rb.Type != RichBlockTypeThinking {
+		t.Fatalf("wrong type %q", rb.Type)
+	}
+	if rb.RichBlockThinking == nil || rb.RichBlockThinking.Text.PlainText != "weighing the options" {
+		t.Fatal("thinking text not decoded")
+	}
+}
+
+func TestRichBlock_ParagraphWithFormatting(t *testing.T) {
+	richBlockRoundTrip(t, `{"type":"paragraph","text":{"type":"bold","text":"hi"}}`)
+}
+
+func TestRichBlock_Divider(t *testing.T) {
+	richBlockRoundTrip(t, `{"type":"divider"}`)
+}
+
+func TestRichBlock_NestedList(t *testing.T) {
+	rb := richBlockRoundTrip(t, `{"type":"list","items":[{"label":"1","blocks":[{"type":"paragraph","text":"first"}]}]}`)
+	if rb.RichBlockList == nil || len(rb.RichBlockList.Items) != 1 {
+		t.Fatal("list items not decoded")
+	}
+	if rb.RichBlockList.Items[0].Blocks[0].Type != RichBlockTypeParagraph {
+		t.Fatal("nested paragraph block not decoded")
+	}
+}
+
+func TestRichBlock_Table(t *testing.T) {
+	richBlockRoundTrip(t, `{"type":"table","cells":[[{"align":"left","valign":"top"},{"text":"h","align":"center","valign":"middle"}]]}`)
+}
+
+func TestRichBlock_BlockQuotationWithBlocks(t *testing.T) {
+	richBlockRoundTrip(t, `{"type":"blockquote","blocks":[{"type":"paragraph","text":"quoted"}]}`)
+}
+
+func TestRichBlock_UnknownType(t *testing.T) {
+	var rb RichBlock
+	if err := json.Unmarshal([]byte(`{"type":"not_a_block"}`), &rb); err == nil {
+		t.Fatal("expected error for unknown RichBlock type")
+	}
+}
+
+func TestRichMessage_RoundTrip(t *testing.T) {
+	src := `{"blocks":[{"type":"thinking","text":"hmm"},{"type":"paragraph","text":"answer"}]}`
+
+	var rm RichMessage
+	if err := json.Unmarshal([]byte(src), &rm); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(rm.Blocks) != 2 {
+		t.Fatalf("expected 2 blocks, got %d", len(rm.Blocks))
+	}
+	if rm.Blocks[0].Type != RichBlockTypeThinking {
+		t.Fatal("first block should be thinking")
+	}
+
+	out, err := json.Marshal(rm)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if string(out) != src {
+		t.Fatalf("round-trip mismatch:\n got %s\nwant %s", out, src)
+	}
+}

--- a/models/rich_message.go
+++ b/models/rich_message.go
@@ -1,0 +1,60 @@
+package models
+
+// RichMessage https://core.telegram.org/bots/api#richmessage
+//
+// Describes a rich formatted message.
+type RichMessage struct {
+	Blocks []RichBlock `json:"blocks"`
+	IsRTL  bool        `json:"is_rtl,omitempty"`
+}
+
+// InputRichMessage https://core.telegram.org/bots/api#inputrichmessage
+//
+// Describes a rich formatted message to be sent. The thinking block is expressed
+// by the custom HTML tag <tg-thinking> within HTML.
+type InputRichMessage struct {
+	HTML                string `json:"html,omitempty"`
+	Markdown            string `json:"markdown,omitempty"`
+	IsRTL               bool   `json:"is_rtl,omitempty"`
+	SkipEntityDetection bool   `json:"skip_entity_detection,omitempty"`
+}
+
+// InputRichMessageContent https://core.telegram.org/bots/api#inputrichmessagecontent
+//
+// Represents the content of a rich message to be sent as the result of an inline
+// query.
+type InputRichMessageContent struct {
+	RichMessage InputRichMessage `json:"rich_message"`
+}
+
+// RichBlockCaption https://core.telegram.org/bots/api#richblockcaption
+//
+// Caption of a rich formatted block.
+type RichBlockCaption struct {
+	Text   RichText  `json:"text"`
+	Credit *RichText `json:"credit,omitempty"`
+}
+
+// RichBlockListItem https://core.telegram.org/bots/api#richblocklistitem
+//
+// An item of a list.
+type RichBlockListItem struct {
+	Label       string      `json:"label"`
+	Blocks      []RichBlock `json:"blocks"`
+	HasCheckbox bool        `json:"has_checkbox,omitempty"`
+	IsChecked   bool        `json:"is_checked,omitempty"`
+	Value       int         `json:"value,omitempty"`
+	Type        string      `json:"type,omitempty"`
+}
+
+// RichBlockTableCell https://core.telegram.org/bots/api#richblocktablecell
+//
+// Cell in a table.
+type RichBlockTableCell struct {
+	Text     *RichText `json:"text,omitempty"`
+	IsHeader bool      `json:"is_header,omitempty"`
+	Colspan  int       `json:"colspan,omitempty"`
+	Rowspan  int       `json:"rowspan,omitempty"`
+	Align    string    `json:"align"`
+	Valign   string    `json:"valign"`
+}

--- a/models/rich_message_test.go
+++ b/models/rich_message_test.go
@@ -1,0 +1,54 @@
+package models
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestMessage_RichMessage verifies a received Message carrying a rich_message
+// (the single inbound integration point of Bot API 10.1) decodes into the
+// RichMessage field.
+func TestMessage_RichMessage(t *testing.T) {
+	src := `{"message_id":42,"date":1,"chat":{"id":1,"type":"private"},"rich_message":{"blocks":[{"type":"thinking","text":"deciding"},{"type":"paragraph","text":"done"}]}}`
+
+	var m Message
+	if err := json.Unmarshal([]byte(src), &m); err != nil {
+		t.Fatalf("unmarshal message: %v", err)
+	}
+	if m.RichMessage == nil {
+		t.Fatal("rich_message not decoded")
+	}
+	if len(m.RichMessage.Blocks) != 2 {
+		t.Fatalf("expected 2 blocks, got %d", len(m.RichMessage.Blocks))
+	}
+	if m.RichMessage.Blocks[0].Type != RichBlockTypeThinking {
+		t.Fatal("first block should be thinking")
+	}
+}
+
+// TestInputRichMessage_ThinkingTag verifies the send-side shape: a thinking
+// block is carried as the custom <tg-thinking> HTML tag inside HTML.
+func TestInputRichMessage_ThinkingTag(t *testing.T) {
+	in := InputRichMessage{HTML: "<tg-thinking>reasoning</tg-thinking>final answer"}
+
+	out, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	// json.Marshal HTML-escapes angle brackets; assert the decoded value instead.
+	var back InputRichMessage
+	if err := json.Unmarshal(out, &back); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if back.HTML != in.HTML {
+		t.Fatalf("HTML round-trip mismatch: %q", back.HTML)
+	}
+	if !strings.Contains(back.HTML, "<tg-thinking>") {
+		t.Fatal("expected <tg-thinking> tag preserved")
+	}
+	// Empty optional fields must be omitted so we never send conflicting html+markdown.
+	if strings.Contains(string(out), "markdown") {
+		t.Fatalf("empty markdown should be omitted, got %s", out)
+	}
+}

--- a/models/rich_text.go
+++ b/models/rich_text.go
@@ -1,0 +1,464 @@
+package models
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+// RichTextType https://core.telegram.org/bots/api#richtext
+type RichTextType string
+
+const (
+	RichTextTypeBold                   RichTextType = "bold"
+	RichTextTypeItalic                 RichTextType = "italic"
+	RichTextTypeUnderline              RichTextType = "underline"
+	RichTextTypeStrikethrough          RichTextType = "strikethrough"
+	RichTextTypeSpoiler                RichTextType = "spoiler"
+	RichTextTypeDateTime               RichTextType = "date_time"
+	RichTextTypeTextMention            RichTextType = "text_mention"
+	RichTextTypeSubscript              RichTextType = "subscript"
+	RichTextTypeSuperscript            RichTextType = "superscript"
+	RichTextTypeMarked                 RichTextType = "marked"
+	RichTextTypeCode                   RichTextType = "code"
+	RichTextTypeCustomEmoji            RichTextType = "custom_emoji"
+	RichTextTypeMathematicalExpression RichTextType = "mathematical_expression"
+	RichTextTypeURL                    RichTextType = "url"
+	RichTextTypeEmailAddress           RichTextType = "email_address"
+	RichTextTypePhoneNumber            RichTextType = "phone_number"
+	RichTextTypeBankCardNumber         RichTextType = "bank_card_number"
+	RichTextTypeMention                RichTextType = "mention"
+	RichTextTypeHashtag                RichTextType = "hashtag"
+	RichTextTypeCashtag                RichTextType = "cashtag"
+	RichTextTypeBotCommand             RichTextType = "bot_command"
+	RichTextTypeAnchor                 RichTextType = "anchor"
+	RichTextTypeAnchorLink             RichTextType = "anchor_link"
+	RichTextTypeReference              RichTextType = "reference"
+	RichTextTypeReferenceLink          RichTextType = "reference_link"
+)
+
+// RichText https://core.telegram.org/bots/api#richtext
+//
+// RichText is polymorphic: a rich text value is encoded by Telegram as a bare
+// JSON string, a JSON array of RichText (a sequence), or a tagged object with a
+// "type" discriminator. The form is recorded in Type: it is the empty string for
+// the plain-string and array forms, set in PlainText and Array respectively, and
+// otherwise holds the discriminator with the matching variant pointer populated.
+type RichText struct {
+	Type      RichTextType
+	PlainText string
+	Array     []RichText
+
+	RichTextBold                   *RichTextBold
+	RichTextItalic                 *RichTextItalic
+	RichTextUnderline              *RichTextUnderline
+	RichTextStrikethrough          *RichTextStrikethrough
+	RichTextSpoiler                *RichTextSpoiler
+	RichTextDateTime               *RichTextDateTime
+	RichTextTextMention            *RichTextTextMention
+	RichTextSubscript              *RichTextSubscript
+	RichTextSuperscript            *RichTextSuperscript
+	RichTextMarked                 *RichTextMarked
+	RichTextCode                   *RichTextCode
+	RichTextCustomEmoji            *RichTextCustomEmoji
+	RichTextMathematicalExpression *RichTextMathematicalExpression
+	RichTextURL                    *RichTextURL
+	RichTextEmailAddress           *RichTextEmailAddress
+	RichTextPhoneNumber            *RichTextPhoneNumber
+	RichTextBankCardNumber         *RichTextBankCardNumber
+	RichTextMention                *RichTextMention
+	RichTextHashtag                *RichTextHashtag
+	RichTextCashtag                *RichTextCashtag
+	RichTextBotCommand             *RichTextBotCommand
+	RichTextAnchor                 *RichTextAnchor
+	RichTextAnchorLink             *RichTextAnchorLink
+	RichTextReference              *RichTextReference
+	RichTextReferenceLink          *RichTextReferenceLink
+}
+
+// MarshalJSON implements json.Marshaler. The value receiver ensures the encoding
+// is applied even when a RichText is reached as a (non-pointer) struct field.
+func (rt RichText) MarshalJSON() ([]byte, error) {
+	if rt.Array != nil {
+		return json.Marshal(rt.Array)
+	}
+
+	switch rt.Type {
+	case "":
+		return json.Marshal(rt.PlainText)
+	case RichTextTypeBold:
+		rt.RichTextBold.Type = RichTextTypeBold
+		return json.Marshal(rt.RichTextBold)
+	case RichTextTypeItalic:
+		rt.RichTextItalic.Type = RichTextTypeItalic
+		return json.Marshal(rt.RichTextItalic)
+	case RichTextTypeUnderline:
+		rt.RichTextUnderline.Type = RichTextTypeUnderline
+		return json.Marshal(rt.RichTextUnderline)
+	case RichTextTypeStrikethrough:
+		rt.RichTextStrikethrough.Type = RichTextTypeStrikethrough
+		return json.Marshal(rt.RichTextStrikethrough)
+	case RichTextTypeSpoiler:
+		rt.RichTextSpoiler.Type = RichTextTypeSpoiler
+		return json.Marshal(rt.RichTextSpoiler)
+	case RichTextTypeDateTime:
+		rt.RichTextDateTime.Type = RichTextTypeDateTime
+		return json.Marshal(rt.RichTextDateTime)
+	case RichTextTypeTextMention:
+		rt.RichTextTextMention.Type = RichTextTypeTextMention
+		return json.Marshal(rt.RichTextTextMention)
+	case RichTextTypeSubscript:
+		rt.RichTextSubscript.Type = RichTextTypeSubscript
+		return json.Marshal(rt.RichTextSubscript)
+	case RichTextTypeSuperscript:
+		rt.RichTextSuperscript.Type = RichTextTypeSuperscript
+		return json.Marshal(rt.RichTextSuperscript)
+	case RichTextTypeMarked:
+		rt.RichTextMarked.Type = RichTextTypeMarked
+		return json.Marshal(rt.RichTextMarked)
+	case RichTextTypeCode:
+		rt.RichTextCode.Type = RichTextTypeCode
+		return json.Marshal(rt.RichTextCode)
+	case RichTextTypeCustomEmoji:
+		rt.RichTextCustomEmoji.Type = RichTextTypeCustomEmoji
+		return json.Marshal(rt.RichTextCustomEmoji)
+	case RichTextTypeMathematicalExpression:
+		rt.RichTextMathematicalExpression.Type = RichTextTypeMathematicalExpression
+		return json.Marshal(rt.RichTextMathematicalExpression)
+	case RichTextTypeURL:
+		rt.RichTextURL.Type = RichTextTypeURL
+		return json.Marshal(rt.RichTextURL)
+	case RichTextTypeEmailAddress:
+		rt.RichTextEmailAddress.Type = RichTextTypeEmailAddress
+		return json.Marshal(rt.RichTextEmailAddress)
+	case RichTextTypePhoneNumber:
+		rt.RichTextPhoneNumber.Type = RichTextTypePhoneNumber
+		return json.Marshal(rt.RichTextPhoneNumber)
+	case RichTextTypeBankCardNumber:
+		rt.RichTextBankCardNumber.Type = RichTextTypeBankCardNumber
+		return json.Marshal(rt.RichTextBankCardNumber)
+	case RichTextTypeMention:
+		rt.RichTextMention.Type = RichTextTypeMention
+		return json.Marshal(rt.RichTextMention)
+	case RichTextTypeHashtag:
+		rt.RichTextHashtag.Type = RichTextTypeHashtag
+		return json.Marshal(rt.RichTextHashtag)
+	case RichTextTypeCashtag:
+		rt.RichTextCashtag.Type = RichTextTypeCashtag
+		return json.Marshal(rt.RichTextCashtag)
+	case RichTextTypeBotCommand:
+		rt.RichTextBotCommand.Type = RichTextTypeBotCommand
+		return json.Marshal(rt.RichTextBotCommand)
+	case RichTextTypeAnchor:
+		rt.RichTextAnchor.Type = RichTextTypeAnchor
+		return json.Marshal(rt.RichTextAnchor)
+	case RichTextTypeAnchorLink:
+		rt.RichTextAnchorLink.Type = RichTextTypeAnchorLink
+		return json.Marshal(rt.RichTextAnchorLink)
+	case RichTextTypeReference:
+		rt.RichTextReference.Type = RichTextTypeReference
+		return json.Marshal(rt.RichTextReference)
+	case RichTextTypeReferenceLink:
+		rt.RichTextReferenceLink.Type = RichTextTypeReferenceLink
+		return json.Marshal(rt.RichTextReferenceLink)
+	}
+
+	return nil, fmt.Errorf("unsupported RichText type %q", rt.Type)
+}
+
+func (rt *RichText) UnmarshalJSON(data []byte) error {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return nil
+	}
+
+	switch trimmed[0] {
+	case '"':
+		rt.Type = ""
+		return json.Unmarshal(trimmed, &rt.PlainText)
+	case '[':
+		rt.Type = ""
+		return json.Unmarshal(trimmed, &rt.Array)
+	case '{':
+		// fall through to the tagged-object dispatch below
+	default:
+		return fmt.Errorf("unexpected RichText JSON: %s", trimmed)
+	}
+
+	v := struct {
+		Type RichTextType `json:"type"`
+	}{}
+	if err := json.Unmarshal(trimmed, &v); err != nil {
+		return err
+	}
+
+	switch v.Type {
+	case RichTextTypeBold:
+		rt.Type = RichTextTypeBold
+		rt.RichTextBold = &RichTextBold{}
+		return json.Unmarshal(trimmed, rt.RichTextBold)
+	case RichTextTypeItalic:
+		rt.Type = RichTextTypeItalic
+		rt.RichTextItalic = &RichTextItalic{}
+		return json.Unmarshal(trimmed, rt.RichTextItalic)
+	case RichTextTypeUnderline:
+		rt.Type = RichTextTypeUnderline
+		rt.RichTextUnderline = &RichTextUnderline{}
+		return json.Unmarshal(trimmed, rt.RichTextUnderline)
+	case RichTextTypeStrikethrough:
+		rt.Type = RichTextTypeStrikethrough
+		rt.RichTextStrikethrough = &RichTextStrikethrough{}
+		return json.Unmarshal(trimmed, rt.RichTextStrikethrough)
+	case RichTextTypeSpoiler:
+		rt.Type = RichTextTypeSpoiler
+		rt.RichTextSpoiler = &RichTextSpoiler{}
+		return json.Unmarshal(trimmed, rt.RichTextSpoiler)
+	case RichTextTypeDateTime:
+		rt.Type = RichTextTypeDateTime
+		rt.RichTextDateTime = &RichTextDateTime{}
+		return json.Unmarshal(trimmed, rt.RichTextDateTime)
+	case RichTextTypeTextMention:
+		rt.Type = RichTextTypeTextMention
+		rt.RichTextTextMention = &RichTextTextMention{}
+		return json.Unmarshal(trimmed, rt.RichTextTextMention)
+	case RichTextTypeSubscript:
+		rt.Type = RichTextTypeSubscript
+		rt.RichTextSubscript = &RichTextSubscript{}
+		return json.Unmarshal(trimmed, rt.RichTextSubscript)
+	case RichTextTypeSuperscript:
+		rt.Type = RichTextTypeSuperscript
+		rt.RichTextSuperscript = &RichTextSuperscript{}
+		return json.Unmarshal(trimmed, rt.RichTextSuperscript)
+	case RichTextTypeMarked:
+		rt.Type = RichTextTypeMarked
+		rt.RichTextMarked = &RichTextMarked{}
+		return json.Unmarshal(trimmed, rt.RichTextMarked)
+	case RichTextTypeCode:
+		rt.Type = RichTextTypeCode
+		rt.RichTextCode = &RichTextCode{}
+		return json.Unmarshal(trimmed, rt.RichTextCode)
+	case RichTextTypeCustomEmoji:
+		rt.Type = RichTextTypeCustomEmoji
+		rt.RichTextCustomEmoji = &RichTextCustomEmoji{}
+		return json.Unmarshal(trimmed, rt.RichTextCustomEmoji)
+	case RichTextTypeMathematicalExpression:
+		rt.Type = RichTextTypeMathematicalExpression
+		rt.RichTextMathematicalExpression = &RichTextMathematicalExpression{}
+		return json.Unmarshal(trimmed, rt.RichTextMathematicalExpression)
+	case RichTextTypeURL:
+		rt.Type = RichTextTypeURL
+		rt.RichTextURL = &RichTextURL{}
+		return json.Unmarshal(trimmed, rt.RichTextURL)
+	case RichTextTypeEmailAddress:
+		rt.Type = RichTextTypeEmailAddress
+		rt.RichTextEmailAddress = &RichTextEmailAddress{}
+		return json.Unmarshal(trimmed, rt.RichTextEmailAddress)
+	case RichTextTypePhoneNumber:
+		rt.Type = RichTextTypePhoneNumber
+		rt.RichTextPhoneNumber = &RichTextPhoneNumber{}
+		return json.Unmarshal(trimmed, rt.RichTextPhoneNumber)
+	case RichTextTypeBankCardNumber:
+		rt.Type = RichTextTypeBankCardNumber
+		rt.RichTextBankCardNumber = &RichTextBankCardNumber{}
+		return json.Unmarshal(trimmed, rt.RichTextBankCardNumber)
+	case RichTextTypeMention:
+		rt.Type = RichTextTypeMention
+		rt.RichTextMention = &RichTextMention{}
+		return json.Unmarshal(trimmed, rt.RichTextMention)
+	case RichTextTypeHashtag:
+		rt.Type = RichTextTypeHashtag
+		rt.RichTextHashtag = &RichTextHashtag{}
+		return json.Unmarshal(trimmed, rt.RichTextHashtag)
+	case RichTextTypeCashtag:
+		rt.Type = RichTextTypeCashtag
+		rt.RichTextCashtag = &RichTextCashtag{}
+		return json.Unmarshal(trimmed, rt.RichTextCashtag)
+	case RichTextTypeBotCommand:
+		rt.Type = RichTextTypeBotCommand
+		rt.RichTextBotCommand = &RichTextBotCommand{}
+		return json.Unmarshal(trimmed, rt.RichTextBotCommand)
+	case RichTextTypeAnchor:
+		rt.Type = RichTextTypeAnchor
+		rt.RichTextAnchor = &RichTextAnchor{}
+		return json.Unmarshal(trimmed, rt.RichTextAnchor)
+	case RichTextTypeAnchorLink:
+		rt.Type = RichTextTypeAnchorLink
+		rt.RichTextAnchorLink = &RichTextAnchorLink{}
+		return json.Unmarshal(trimmed, rt.RichTextAnchorLink)
+	case RichTextTypeReference:
+		rt.Type = RichTextTypeReference
+		rt.RichTextReference = &RichTextReference{}
+		return json.Unmarshal(trimmed, rt.RichTextReference)
+	case RichTextTypeReferenceLink:
+		rt.Type = RichTextTypeReferenceLink
+		rt.RichTextReferenceLink = &RichTextReferenceLink{}
+		return json.Unmarshal(trimmed, rt.RichTextReferenceLink)
+	}
+
+	return fmt.Errorf("unsupported RichText type %q", v.Type)
+}
+
+// RichTextBold https://core.telegram.org/bots/api#richtextbold
+type RichTextBold struct {
+	Type RichTextType `json:"type"`
+	Text RichText     `json:"text"`
+}
+
+// RichTextItalic https://core.telegram.org/bots/api#richtextitalic
+type RichTextItalic struct {
+	Type RichTextType `json:"type"`
+	Text RichText     `json:"text"`
+}
+
+// RichTextUnderline https://core.telegram.org/bots/api#richtextunderline
+type RichTextUnderline struct {
+	Type RichTextType `json:"type"`
+	Text RichText     `json:"text"`
+}
+
+// RichTextStrikethrough https://core.telegram.org/bots/api#richtextstrikethrough
+type RichTextStrikethrough struct {
+	Type RichTextType `json:"type"`
+	Text RichText     `json:"text"`
+}
+
+// RichTextSpoiler https://core.telegram.org/bots/api#richtextspoiler
+type RichTextSpoiler struct {
+	Type RichTextType `json:"type"`
+	Text RichText     `json:"text"`
+}
+
+// RichTextDateTime https://core.telegram.org/bots/api#richtextdatetime
+type RichTextDateTime struct {
+	Type           RichTextType `json:"type"`
+	Text           RichText     `json:"text"`
+	UnixTime       int          `json:"unix_time"`
+	DateTimeFormat string       `json:"date_time_format"`
+}
+
+// RichTextTextMention https://core.telegram.org/bots/api#richtexttextmention
+type RichTextTextMention struct {
+	Type RichTextType `json:"type"`
+	Text RichText     `json:"text"`
+	User *User        `json:"user"`
+}
+
+// RichTextSubscript https://core.telegram.org/bots/api#richtextsubscript
+type RichTextSubscript struct {
+	Type RichTextType `json:"type"`
+	Text RichText     `json:"text"`
+}
+
+// RichTextSuperscript https://core.telegram.org/bots/api#richtextsuperscript
+type RichTextSuperscript struct {
+	Type RichTextType `json:"type"`
+	Text RichText     `json:"text"`
+}
+
+// RichTextMarked https://core.telegram.org/bots/api#richtextmarked
+type RichTextMarked struct {
+	Type RichTextType `json:"type"`
+	Text RichText     `json:"text"`
+}
+
+// RichTextCode https://core.telegram.org/bots/api#richtextcode
+type RichTextCode struct {
+	Type RichTextType `json:"type"`
+	Text RichText     `json:"text"`
+}
+
+// RichTextCustomEmoji https://core.telegram.org/bots/api#richtextcustomemoji
+type RichTextCustomEmoji struct {
+	Type            RichTextType `json:"type"`
+	CustomEmojiID   string       `json:"custom_emoji_id"`
+	AlternativeText string       `json:"alternative_text"`
+}
+
+// RichTextMathematicalExpression https://core.telegram.org/bots/api#richtextmathematicalexpression
+type RichTextMathematicalExpression struct {
+	Type       RichTextType `json:"type"`
+	Expression string       `json:"expression"`
+}
+
+// RichTextURL https://core.telegram.org/bots/api#richtexturl
+type RichTextURL struct {
+	Type RichTextType `json:"type"`
+	Text RichText     `json:"text"`
+	URL  string       `json:"url"`
+}
+
+// RichTextEmailAddress https://core.telegram.org/bots/api#richtextemailaddress
+type RichTextEmailAddress struct {
+	Type         RichTextType `json:"type"`
+	Text         RichText     `json:"text"`
+	EmailAddress string       `json:"email_address"`
+}
+
+// RichTextPhoneNumber https://core.telegram.org/bots/api#richtextphonenumber
+type RichTextPhoneNumber struct {
+	Type        RichTextType `json:"type"`
+	Text        RichText     `json:"text"`
+	PhoneNumber string       `json:"phone_number"`
+}
+
+// RichTextBankCardNumber https://core.telegram.org/bots/api#richtextbankcardnumber
+type RichTextBankCardNumber struct {
+	Type           RichTextType `json:"type"`
+	Text           RichText     `json:"text"`
+	BankCardNumber string       `json:"bank_card_number"`
+}
+
+// RichTextMention https://core.telegram.org/bots/api#richtextmention
+type RichTextMention struct {
+	Type     RichTextType `json:"type"`
+	Text     RichText     `json:"text"`
+	Username string       `json:"username"`
+}
+
+// RichTextHashtag https://core.telegram.org/bots/api#richtexthashtag
+type RichTextHashtag struct {
+	Type    RichTextType `json:"type"`
+	Text    RichText     `json:"text"`
+	Hashtag string       `json:"hashtag"`
+}
+
+// RichTextCashtag https://core.telegram.org/bots/api#richtextcashtag
+type RichTextCashtag struct {
+	Type    RichTextType `json:"type"`
+	Text    RichText     `json:"text"`
+	Cashtag string       `json:"cashtag"`
+}
+
+// RichTextBotCommand https://core.telegram.org/bots/api#richtextbotcommand
+type RichTextBotCommand struct {
+	Type       RichTextType `json:"type"`
+	Text       RichText     `json:"text"`
+	BotCommand string       `json:"bot_command"`
+}
+
+// RichTextAnchor https://core.telegram.org/bots/api#richtextanchor
+type RichTextAnchor struct {
+	Type RichTextType `json:"type"`
+	Name string       `json:"name"`
+}
+
+// RichTextAnchorLink https://core.telegram.org/bots/api#richtextanchorlink
+type RichTextAnchorLink struct {
+	Type       RichTextType `json:"type"`
+	Text       RichText     `json:"text"`
+	AnchorName string       `json:"anchor_name"`
+}
+
+// RichTextReference https://core.telegram.org/bots/api#richtextreference
+type RichTextReference struct {
+	Type RichTextType `json:"type"`
+	Text RichText     `json:"text"`
+	Name string       `json:"name"`
+}
+
+// RichTextReferenceLink https://core.telegram.org/bots/api#richtextreferencelink
+type RichTextReferenceLink struct {
+	Type          RichTextType `json:"type"`
+	Text          RichText     `json:"text"`
+	ReferenceName string       `json:"reference_name"`
+}

--- a/models/rich_text_test.go
+++ b/models/rich_text_test.go
@@ -1,0 +1,119 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// richTextRoundTrip unmarshals src into a RichText then marshals it back and
+// asserts the JSON is byte-identical. Our struct field order (type, then text,
+// then extras) matches Telegram's encoding, so a string compare is meaningful.
+func richTextRoundTrip(t *testing.T, src string) RichText {
+	t.Helper()
+
+	var rt RichText
+	if err := json.Unmarshal([]byte(src), &rt); err != nil {
+		t.Fatalf("unmarshal %s: %v", src, err)
+	}
+
+	out, err := json.Marshal(rt)
+	if err != nil {
+		t.Fatalf("marshal %s: %v", src, err)
+	}
+
+	if string(out) != src {
+		t.Fatalf("round-trip mismatch:\n got %s\nwant %s", out, src)
+	}
+
+	return rt
+}
+
+func TestRichText_PlainString(t *testing.T) {
+	rt := richTextRoundTrip(t, `"hello world"`)
+	if rt.Type != "" {
+		t.Fatalf("plain string should have empty Type, got %q", rt.Type)
+	}
+	if rt.PlainText != "hello world" {
+		t.Fatalf("wrong PlainText %q", rt.PlainText)
+	}
+}
+
+func TestRichText_Array(t *testing.T) {
+	rt := richTextRoundTrip(t, `["a","b","c"]`)
+	if len(rt.Array) != 3 {
+		t.Fatalf("expected 3 array elements, got %d", len(rt.Array))
+	}
+	if rt.Array[1].PlainText != "b" {
+		t.Fatalf("wrong array element %q", rt.Array[1].PlainText)
+	}
+}
+
+func TestRichText_TaggedBold(t *testing.T) {
+	rt := richTextRoundTrip(t, `{"type":"bold","text":"hi"}`)
+	if rt.Type != RichTextTypeBold {
+		t.Fatalf("wrong type %q", rt.Type)
+	}
+	if rt.RichTextBold == nil || rt.RichTextBold.Text.PlainText != "hi" {
+		t.Fatal("bold text not decoded")
+	}
+}
+
+func TestRichText_Recursive(t *testing.T) {
+	// bold wrapping italic wrapping a plain string — exercises the recursive
+	// Text RichText field through both directions.
+	rt := richTextRoundTrip(t, `{"type":"bold","text":{"type":"italic","text":"x"}}`)
+	if rt.RichTextBold == nil {
+		t.Fatal("outer bold nil")
+	}
+	inner := rt.RichTextBold.Text
+	if inner.Type != RichTextTypeItalic || inner.RichTextItalic == nil {
+		t.Fatal("inner italic not decoded")
+	}
+	if inner.RichTextItalic.Text.PlainText != "x" {
+		t.Fatal("innermost plain text wrong")
+	}
+}
+
+func TestRichText_ArrayOfMixed(t *testing.T) {
+	// a sequence mixing a plain string and a tagged object, like a paragraph body.
+	rt := richTextRoundTrip(t, `[{"type":"bold","text":"a"},"b"]`)
+	if len(rt.Array) != 2 {
+		t.Fatalf("expected 2 elements, got %d", len(rt.Array))
+	}
+	if rt.Array[0].Type != RichTextTypeBold {
+		t.Fatal("first element should be bold")
+	}
+	if rt.Array[1].PlainText != "b" {
+		t.Fatal("second element should be plain 'b'")
+	}
+}
+
+func TestRichText_VariantsWithExtraFields(t *testing.T) {
+	for _, src := range []string{
+		`{"type":"url","text":"link","url":"https://example.com"}`,
+		`{"type":"custom_emoji","custom_emoji_id":"123","alternative_text":"🙂"}`,
+		`{"type":"mathematical_expression","expression":"x^2"}`,
+		`{"type":"anchor","name":"top"}`,
+		`{"type":"reference_link","text":"see","reference_name":"r1"}`,
+	} {
+		richTextRoundTrip(t, src)
+	}
+}
+
+func TestRichText_Null(t *testing.T) {
+	var rt RichText
+	if err := rt.UnmarshalJSON([]byte("null")); err != nil {
+		t.Fatalf("null should not error: %v", err)
+	}
+	if rt.Type != "" || rt.PlainText != "" || rt.Array != nil {
+		t.Fatal("null should leave RichText zero")
+	}
+}
+
+func TestRichText_UnknownType(t *testing.T) {
+	var rt RichText
+	err := rt.UnmarshalJSON([]byte(`{"type":"definitely_not_a_real_type"}`))
+	if err == nil {
+		t.Fatal("expected error for unknown RichText type")
+	}
+}


### PR DESCRIPTION
## Bot API 10.1 — Rich Messages

Adds the [Rich Messages](https://core.telegram.org/bots/api#june-11-2026) framework introduced in Bot API 10.1 (June 11, 2026). Follows the existing patterns in the library (the `reaction.go` discriminated-union style for the type unions, and the `rawRequest` wrapper style for methods).

### Methods (`methods.go` / `methods_params.go`)
- `sendRichMessage`
- `sendRichMessageDraft`
- `rich_message` parameter added to `editMessageText`

### Types (`models/`)
- **Send side:** `InputRichMessage`, `InputRichMessageContent`
- **Receive side:** `RichMessage` (+ `rich_message` field on `Message`); the `RichBlock` union (21 variants, incl. `RichBlockThinking`); the `RichText` union; plus `RichBlockCaption`, `RichBlockListItem`, `RichBlockTableCell`

### Notes for review
- **`RichText` is polymorphic** — a value is a bare JSON string, an array of `RichText`, or a tagged object (25 variants, several recursively nesting `text`). It has a custom codec that dispatches on the first JSON byte; this is the one type that goes beyond the plain `reaction.go` shape.
- **Value receiver on `MarshalJSON`** for `RichText`/`RichBlock` (vs the pointer receiver in `reaction.go`). This is deliberate: `RichText` appears as a non-pointer struct field (`Text RichText`) throughout the variants, and `encoding/json` silently skips a pointer-receiver `MarshalJSON` on non-addressable values — so a value receiver is required for correct marshaling of nested rich text. `RichBlock` uses a value receiver too for consistency.
- `RichBlockThinking` is valid only in `sendRichMessageDraft` per the spec (ephemeral), and the field type is modeled accordingly.

### Tests
Round-trip (unmarshal → marshal → assert) coverage for both unions — including the polymorphic string/array/object forms and recursive nesting — and request-shape tests for the two new methods. `gofmt`, `go vet`, and `go test ./...` are clean.

README "Supports Bot API version" and CHANGELOG bumped to 10.1.
