### PR TITLE
feat: add Bot API 10.1 rich messages support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Support Bot API 10.1 Rich Messages: add `InputRichMessage`, `RichMessage`, `RichText`/`RichBlock` types, `InputRichMessageContent`, `Message.RichMessage`, and `sendRichMessage` / `sendRichMessageDraft` methods
+
 ## v1.21.0 (2026-05-22)
 
 - Support Bot API 9.6 & 10.0, multipart fixes — closes #279 #280, fixes #273 #274 #271 #277 (#281)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 > [Telegram Group](https://t.me/gotelegrambotui)
 
-> Supports Bot API version: [10.0](https://core.telegram.org/bots/api#may-8-2026) from May 8, 2026
+> Supports Bot API version: [10.1](https://core.telegram.org/bots/api#june-11-2026) from June 11, 2026
 
 It's a Go zero-dependencies telegram bot framework
 

--- a/examples/inline-rich-message/main.go
+++ b/examples/inline-rich-message/main.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"context"
+	"os"
+	"os/signal"
+
+	"github.com/go-telegram/bot"
+	"github.com/go-telegram/bot/models"
+)
+
+// Inline rich message example.
+//
+// Use inline mode (@botname some_text) to trigger the bot. The bot returns a
+// single InlineQueryResultArticle candidate. When the user selects it, the bot
+// sends a Bot API 10.1 Rich Message that contains a title, a description and a
+// photo block.
+//
+// Notes about the image URL:
+//   - thumbnail_url is only used for the inline candidate list preview.
+//   - The Rich Message photo URL is provided inside the markdown media block and
+//     is NOT shown as plain text in the message body.
+//   - The photo URL is still fetched by Telegram, so it must be treated as a
+//     publicly accessible resource.
+func main() {
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer cancel()
+
+	opts := []bot.Option{
+		bot.WithDefaultHandler(handler),
+	}
+
+	// The token is read from the environment; never hard-code a bot token.
+	b, err := bot.New(os.Getenv("EXAMPLE_TELEGRAM_BOT_TOKEN"), opts...)
+	if nil != err {
+		// panics for the sake of simplicity.
+		// you should handle this error properly in your code.
+		panic(err)
+	}
+
+	b.Start(ctx)
+}
+
+func handler(ctx context.Context, b *bot.Bot, update *models.Update) {
+	if update.InlineQuery == nil {
+		return
+	}
+
+	// thumbnail_url is used for the inline candidate list only.
+	const thumbnailURL = "https://cdn.example.com/thumb.jpg"
+	// photoURL is a publicly accessible resource; it is embedded in the rich
+	// message media block, not written into the visible message text.
+	const photoURL = "https://cdn.example.com/photo.jpg"
+
+	richMarkdown := "# Shared title\n\n" +
+		"Some descriptive text for the rich message.\n\n" +
+		"![Preview](" + photoURL + ")"
+
+	results := []models.InlineQueryResult{
+		&models.InlineQueryResultArticle{
+			ID:           "share_1",
+			Title:        "Title",
+			Description:  "Description",
+			ThumbnailURL: thumbnailURL,
+			// The Article URL field is intentionally left unset.
+			InputMessageContent: &models.InputRichMessageContent{
+				RichMessage: models.InputRichMessage{
+					Markdown: richMarkdown,
+				},
+			},
+		},
+	}
+
+	b.AnswerInlineQuery(ctx, &bot.AnswerInlineQueryParams{
+		InlineQueryID: update.InlineQuery.ID,
+		Results:       results,
+	})
+}

--- a/methods.go
+++ b/methods.go
@@ -1114,6 +1114,20 @@ func (b *Bot) SendMessageDraft(ctx context.Context, params *SendMessageDraftPara
 	return result, err
 }
 
+// SendRichMessage https://core.telegram.org/bots/api#sendrichmessage
+func (b *Bot) SendRichMessage(ctx context.Context, params *SendRichMessageParams) (*models.Message, error) {
+	result := &models.Message{}
+	err := b.rawRequest(ctx, "sendRichMessage", params, result)
+	return result, err
+}
+
+// SendRichMessageDraft https://core.telegram.org/bots/api#sendrichmessagedraft
+func (b *Bot) SendRichMessageDraft(ctx context.Context, params *SendRichMessageDraftParams) (bool, error) {
+	var result bool
+	err := b.rawRequest(ctx, "sendRichMessageDraft", params, &result)
+	return result, err
+}
+
 // RepostStory https://core.telegram.org/bots/api#repoststory
 func (b *Bot) RepostStory(ctx context.Context, params *RepostStoryParams) (*models.Story, error) {
 	result := &models.Story{}

--- a/methods_params.go
+++ b/methods_params.go
@@ -1320,6 +1320,30 @@ type SendMessageDraftParams struct {
 	Entities             []models.MessageEntity `json:"entities,omitempty"`
 }
 
+// SendRichMessageParams https://core.telegram.org/bots/api#sendrichmessage
+type SendRichMessageParams struct {
+	BusinessConnectionID    string                          `json:"business_connection_id,omitempty"`
+	ChatID                  any                             `json:"chat_id"`
+	MessageThreadID         int                             `json:"message_thread_id,omitempty"`
+	DirectMessagesTopicID   int                             `json:"direct_messages_topic_id,omitempty"`
+	RichMessage             models.InputRichMessage         `json:"rich_message"`
+	DisableNotification     bool                            `json:"disable_notification,omitempty"`
+	ProtectContent          bool                            `json:"protect_content,omitempty"`
+	AllowPaidBroadcast      bool                            `json:"allow_paid_broadcast,omitempty"`
+	MessageEffectID         string                          `json:"message_effect_id,omitempty"`
+	SuggestedPostParameters *models.SuggestedPostParameters `json:"suggested_post_parameters,omitempty"`
+	ReplyParameters         *models.ReplyParameters         `json:"reply_parameters,omitempty"`
+	ReplyMarkup             models.ReplyMarkup              `json:"reply_markup,omitempty"`
+}
+
+// SendRichMessageDraftParams https://core.telegram.org/bots/api#sendrichmessagedraft
+type SendRichMessageDraftParams struct {
+	ChatID          any                     `json:"chat_id"`
+	MessageThreadID int                     `json:"message_thread_id,omitempty"`
+	DraftID         int                     `json:"draft_id"`
+	RichMessage     models.InputRichMessage `json:"rich_message"`
+}
+
 // RepostStoryParams https://core.telegram.org/bots/api#repoststory
 type RepostStoryParams struct {
 	BusinessConnectionID string `json:"business_connection_id"`

--- a/methods_test.go
+++ b/methods_test.go
@@ -1389,3 +1389,41 @@ func TestBot_Methods(t *testing.T) {
 	})
 
 }
+
+func TestBot_SendRichMessage(t *testing.T) {
+	t.Parallel()
+
+	c := &httpClient{t: t, resp: `{"message_id":99,"text":"foo"}`, reqFields: map[string]string{
+		"chat_id":      "123",
+		"rich_message": `{"markdown":"# Title\n\nDescription"}`,
+	}}
+	b := &Bot{client: c}
+	resp, err := b.SendRichMessage(context.Background(), &SendRichMessageParams{
+		ChatID: 123,
+		RichMessage: models.InputRichMessage{
+			Markdown: "# Title\n\nDescription",
+		},
+	})
+	assertNoErr(t, err)
+	assertEqualInt(t, 99, resp.ID)
+}
+
+func TestBot_SendRichMessageDraft(t *testing.T) {
+	t.Parallel()
+
+	c := &httpClient{t: t, resp: `true`, reqFields: map[string]string{
+		"chat_id":      "123",
+		"draft_id":     "5",
+		"rich_message": `{"markdown":"**hi**"}`,
+	}}
+	b := &Bot{client: c}
+	resp, err := b.SendRichMessageDraft(context.Background(), &SendRichMessageDraftParams{
+		ChatID:  123,
+		DraftID: 5,
+		RichMessage: models.InputRichMessage{
+			Markdown: "**hi**",
+		},
+	})
+	assertNoErr(t, err)
+	assertTrue(t, resp)
+}

--- a/models/inline_query.go
+++ b/models/inline_query.go
@@ -653,6 +653,16 @@ type InputContactMessageContent struct {
 
 func (InputContactMessageContent) inputMessageContentTag() {}
 
+// InputRichMessageContent https://core.telegram.org/bots/api#inputrichmessagecontent
+//
+// Represents the content of a rich message to be sent as the result of an
+// inline query.
+type InputRichMessageContent struct {
+	RichMessage InputRichMessage `json:"rich_message"`
+}
+
+func (InputRichMessageContent) inputMessageContentTag() {}
+
 // LabeledPrice https://core.telegram.org/bots/api#labeledprice
 type LabeledPrice struct {
 	Label  string `json:"label"`

--- a/models/message.go
+++ b/models/message.go
@@ -110,6 +110,7 @@ type Message struct {
 	Text                          string                         `json:"text,omitempty"`
 	Entities                      []MessageEntity                `json:"entities,omitempty"`
 	LinkPreviewOptions            *LinkPreviewOptions            `json:"link_preview_options,omitempty"`
+	RichMessage                   *RichMessage                   `json:"rich_message,omitempty"`
 	SuggestedPostInfo             *SuggestedPostInfo             `json:"suggested_post_info,omitempty"`
 	EffectID                      string                         `json:"effect_id,omitempty"`
 	Animation                     *Animation                     `json:"animation,omitempty"`

--- a/models/rich_message.go
+++ b/models/rich_message.go
@@ -1,0 +1,840 @@
+package models
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+// InputRichMessage https://core.telegram.org/bots/api#inputrichmessage
+//
+// Describes a rich message to be sent. Exactly one of the fields HTML or
+// Markdown must be used.
+type InputRichMessage struct {
+	HTML                string `json:"html,omitempty"`
+	Markdown            string `json:"markdown,omitempty"`
+	IsRTL               bool   `json:"is_rtl,omitempty"`
+	SkipEntityDetection bool   `json:"skip_entity_detection,omitempty"`
+}
+
+// RichMessage https://core.telegram.org/bots/api#richmessage
+//
+// Rich formatted message.
+type RichMessage struct {
+	Blocks []RichBlock `json:"blocks"`
+	IsRTL  bool        `json:"is_rtl,omitempty"`
+}
+
+// RichTextType https://core.telegram.org/bots/api#richtext
+type RichTextType string
+
+const (
+	RichTextTypeBold                   RichTextType = "bold"
+	RichTextTypeItalic                 RichTextType = "italic"
+	RichTextTypeUnderline              RichTextType = "underline"
+	RichTextTypeStrikethrough          RichTextType = "strikethrough"
+	RichTextTypeSpoiler                RichTextType = "spoiler"
+	RichTextTypeDateTime               RichTextType = "date_time"
+	RichTextTypeTextMention            RichTextType = "text_mention"
+	RichTextTypeSubscript              RichTextType = "subscript"
+	RichTextTypeSuperscript            RichTextType = "superscript"
+	RichTextTypeMarked                 RichTextType = "marked"
+	RichTextTypeCode                   RichTextType = "code"
+	RichTextTypeCustomEmoji            RichTextType = "custom_emoji"
+	RichTextTypeMathematicalExpression RichTextType = "mathematical_expression"
+	RichTextTypeURL                    RichTextType = "url"
+	RichTextTypeEmailAddress           RichTextType = "email_address"
+	RichTextTypePhoneNumber            RichTextType = "phone_number"
+	RichTextTypeBankCardNumber         RichTextType = "bank_card_number"
+	RichTextTypeMention                RichTextType = "mention"
+	RichTextTypeHashtag                RichTextType = "hashtag"
+	RichTextTypeCashtag                RichTextType = "cashtag"
+	RichTextTypeBotCommand             RichTextType = "bot_command"
+	RichTextTypeAnchor                 RichTextType = "anchor"
+	RichTextTypeAnchorLink             RichTextType = "anchor_link"
+	RichTextTypeReference              RichTextType = "reference"
+	RichTextTypeReferenceLink          RichTextType = "reference_link"
+)
+
+// RichText https://core.telegram.org/bots/api#richtext
+//
+// Represents a rich formatted text. It can be a plain string (Plain), an array
+// of RichText (Array), or one of the typed entities below.
+type RichText struct {
+	// Plain is set when the rich text is a plain string.
+	Plain *string
+	// Array is set when the rich text is an array of RichText.
+	Array []RichText
+	// Type is the entity type when the rich text is a typed object.
+	Type RichTextType
+
+	Bold                   *RichTextBold
+	Italic                 *RichTextItalic
+	Underline              *RichTextUnderline
+	Strikethrough          *RichTextStrikethrough
+	Spoiler                *RichTextSpoiler
+	DateTime               *RichTextDateTime
+	TextMention            *RichTextTextMention
+	Subscript              *RichTextSubscript
+	Superscript            *RichTextSuperscript
+	Marked                 *RichTextMarked
+	Code                   *RichTextCode
+	CustomEmoji            *RichTextCustomEmoji
+	MathematicalExpression *RichTextMathematicalExpression
+	URL                    *RichTextURL
+	EmailAddress           *RichTextEmailAddress
+	PhoneNumber            *RichTextPhoneNumber
+	BankCardNumber         *RichTextBankCardNumber
+	Mention                *RichTextMention
+	Hashtag                *RichTextHashtag
+	Cashtag                *RichTextCashtag
+	BotCommand             *RichTextBotCommand
+	Anchor                 *RichTextAnchor
+	AnchorLink             *RichTextAnchorLink
+	Reference              *RichTextReference
+	ReferenceLink          *RichTextReferenceLink
+}
+
+func (rt RichText) MarshalJSON() ([]byte, error) {
+	if rt.Plain != nil {
+		return json.Marshal(*rt.Plain)
+	}
+	if rt.Array != nil {
+		return json.Marshal(rt.Array)
+	}
+
+	switch rt.Type {
+	case RichTextTypeBold:
+		rt.Bold.Type = RichTextTypeBold
+		return json.Marshal(rt.Bold)
+	case RichTextTypeItalic:
+		rt.Italic.Type = RichTextTypeItalic
+		return json.Marshal(rt.Italic)
+	case RichTextTypeUnderline:
+		rt.Underline.Type = RichTextTypeUnderline
+		return json.Marshal(rt.Underline)
+	case RichTextTypeStrikethrough:
+		rt.Strikethrough.Type = RichTextTypeStrikethrough
+		return json.Marshal(rt.Strikethrough)
+	case RichTextTypeSpoiler:
+		rt.Spoiler.Type = RichTextTypeSpoiler
+		return json.Marshal(rt.Spoiler)
+	case RichTextTypeDateTime:
+		rt.DateTime.Type = RichTextTypeDateTime
+		return json.Marshal(rt.DateTime)
+	case RichTextTypeTextMention:
+		rt.TextMention.Type = RichTextTypeTextMention
+		return json.Marshal(rt.TextMention)
+	case RichTextTypeSubscript:
+		rt.Subscript.Type = RichTextTypeSubscript
+		return json.Marshal(rt.Subscript)
+	case RichTextTypeSuperscript:
+		rt.Superscript.Type = RichTextTypeSuperscript
+		return json.Marshal(rt.Superscript)
+	case RichTextTypeMarked:
+		rt.Marked.Type = RichTextTypeMarked
+		return json.Marshal(rt.Marked)
+	case RichTextTypeCode:
+		rt.Code.Type = RichTextTypeCode
+		return json.Marshal(rt.Code)
+	case RichTextTypeCustomEmoji:
+		rt.CustomEmoji.Type = RichTextTypeCustomEmoji
+		return json.Marshal(rt.CustomEmoji)
+	case RichTextTypeMathematicalExpression:
+		rt.MathematicalExpression.Type = RichTextTypeMathematicalExpression
+		return json.Marshal(rt.MathematicalExpression)
+	case RichTextTypeURL:
+		rt.URL.Type = RichTextTypeURL
+		return json.Marshal(rt.URL)
+	case RichTextTypeEmailAddress:
+		rt.EmailAddress.Type = RichTextTypeEmailAddress
+		return json.Marshal(rt.EmailAddress)
+	case RichTextTypePhoneNumber:
+		rt.PhoneNumber.Type = RichTextTypePhoneNumber
+		return json.Marshal(rt.PhoneNumber)
+	case RichTextTypeBankCardNumber:
+		rt.BankCardNumber.Type = RichTextTypeBankCardNumber
+		return json.Marshal(rt.BankCardNumber)
+	case RichTextTypeMention:
+		rt.Mention.Type = RichTextTypeMention
+		return json.Marshal(rt.Mention)
+	case RichTextTypeHashtag:
+		rt.Hashtag.Type = RichTextTypeHashtag
+		return json.Marshal(rt.Hashtag)
+	case RichTextTypeCashtag:
+		rt.Cashtag.Type = RichTextTypeCashtag
+		return json.Marshal(rt.Cashtag)
+	case RichTextTypeBotCommand:
+		rt.BotCommand.Type = RichTextTypeBotCommand
+		return json.Marshal(rt.BotCommand)
+	case RichTextTypeAnchor:
+		rt.Anchor.Type = RichTextTypeAnchor
+		return json.Marshal(rt.Anchor)
+	case RichTextTypeAnchorLink:
+		rt.AnchorLink.Type = RichTextTypeAnchorLink
+		return json.Marshal(rt.AnchorLink)
+	case RichTextTypeReference:
+		rt.Reference.Type = RichTextTypeReference
+		return json.Marshal(rt.Reference)
+	case RichTextTypeReferenceLink:
+		rt.ReferenceLink.Type = RichTextTypeReferenceLink
+		return json.Marshal(rt.ReferenceLink)
+	}
+
+	return []byte("null"), nil
+}
+
+func (rt *RichText) UnmarshalJSON(data []byte) error {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 || string(trimmed) == "null" {
+		return nil
+	}
+
+	switch trimmed[0] {
+	case '"':
+		var s string
+		if err := json.Unmarshal(data, &s); err != nil {
+			return err
+		}
+		rt.Plain = &s
+		return nil
+	case '[':
+		var arr []RichText
+		if err := json.Unmarshal(data, &arr); err != nil {
+			return err
+		}
+		rt.Array = arr
+		return nil
+	}
+
+	v := struct {
+		Type RichTextType `json:"type"`
+	}{}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+	rt.Type = v.Type
+
+	switch v.Type {
+	case RichTextTypeBold:
+		rt.Bold = &RichTextBold{}
+		return json.Unmarshal(data, rt.Bold)
+	case RichTextTypeItalic:
+		rt.Italic = &RichTextItalic{}
+		return json.Unmarshal(data, rt.Italic)
+	case RichTextTypeUnderline:
+		rt.Underline = &RichTextUnderline{}
+		return json.Unmarshal(data, rt.Underline)
+	case RichTextTypeStrikethrough:
+		rt.Strikethrough = &RichTextStrikethrough{}
+		return json.Unmarshal(data, rt.Strikethrough)
+	case RichTextTypeSpoiler:
+		rt.Spoiler = &RichTextSpoiler{}
+		return json.Unmarshal(data, rt.Spoiler)
+	case RichTextTypeDateTime:
+		rt.DateTime = &RichTextDateTime{}
+		return json.Unmarshal(data, rt.DateTime)
+	case RichTextTypeTextMention:
+		rt.TextMention = &RichTextTextMention{}
+		return json.Unmarshal(data, rt.TextMention)
+	case RichTextTypeSubscript:
+		rt.Subscript = &RichTextSubscript{}
+		return json.Unmarshal(data, rt.Subscript)
+	case RichTextTypeSuperscript:
+		rt.Superscript = &RichTextSuperscript{}
+		return json.Unmarshal(data, rt.Superscript)
+	case RichTextTypeMarked:
+		rt.Marked = &RichTextMarked{}
+		return json.Unmarshal(data, rt.Marked)
+	case RichTextTypeCode:
+		rt.Code = &RichTextCode{}
+		return json.Unmarshal(data, rt.Code)
+	case RichTextTypeCustomEmoji:
+		rt.CustomEmoji = &RichTextCustomEmoji{}
+		return json.Unmarshal(data, rt.CustomEmoji)
+	case RichTextTypeMathematicalExpression:
+		rt.MathematicalExpression = &RichTextMathematicalExpression{}
+		return json.Unmarshal(data, rt.MathematicalExpression)
+	case RichTextTypeURL:
+		rt.URL = &RichTextURL{}
+		return json.Unmarshal(data, rt.URL)
+	case RichTextTypeEmailAddress:
+		rt.EmailAddress = &RichTextEmailAddress{}
+		return json.Unmarshal(data, rt.EmailAddress)
+	case RichTextTypePhoneNumber:
+		rt.PhoneNumber = &RichTextPhoneNumber{}
+		return json.Unmarshal(data, rt.PhoneNumber)
+	case RichTextTypeBankCardNumber:
+		rt.BankCardNumber = &RichTextBankCardNumber{}
+		return json.Unmarshal(data, rt.BankCardNumber)
+	case RichTextTypeMention:
+		rt.Mention = &RichTextMention{}
+		return json.Unmarshal(data, rt.Mention)
+	case RichTextTypeHashtag:
+		rt.Hashtag = &RichTextHashtag{}
+		return json.Unmarshal(data, rt.Hashtag)
+	case RichTextTypeCashtag:
+		rt.Cashtag = &RichTextCashtag{}
+		return json.Unmarshal(data, rt.Cashtag)
+	case RichTextTypeBotCommand:
+		rt.BotCommand = &RichTextBotCommand{}
+		return json.Unmarshal(data, rt.BotCommand)
+	case RichTextTypeAnchor:
+		rt.Anchor = &RichTextAnchor{}
+		return json.Unmarshal(data, rt.Anchor)
+	case RichTextTypeAnchorLink:
+		rt.AnchorLink = &RichTextAnchorLink{}
+		return json.Unmarshal(data, rt.AnchorLink)
+	case RichTextTypeReference:
+		rt.Reference = &RichTextReference{}
+		return json.Unmarshal(data, rt.Reference)
+	case RichTextTypeReferenceLink:
+		rt.ReferenceLink = &RichTextReferenceLink{}
+		return json.Unmarshal(data, rt.ReferenceLink)
+	}
+
+	return fmt.Errorf("unsupported RichText type %q", v.Type)
+}
+
+// RichTextBold https://core.telegram.org/bots/api#richtextbold
+type RichTextBold struct {
+	Type RichTextType `json:"type"`
+	Text RichText     `json:"text"`
+}
+
+// RichTextItalic https://core.telegram.org/bots/api#richtextitalic
+type RichTextItalic struct {
+	Type RichTextType `json:"type"`
+	Text RichText     `json:"text"`
+}
+
+// RichTextUnderline https://core.telegram.org/bots/api#richtextunderline
+type RichTextUnderline struct {
+	Type RichTextType `json:"type"`
+	Text RichText     `json:"text"`
+}
+
+// RichTextStrikethrough https://core.telegram.org/bots/api#richtextstrikethrough
+type RichTextStrikethrough struct {
+	Type RichTextType `json:"type"`
+	Text RichText     `json:"text"`
+}
+
+// RichTextSpoiler https://core.telegram.org/bots/api#richtextspoiler
+type RichTextSpoiler struct {
+	Type RichTextType `json:"type"`
+	Text RichText     `json:"text"`
+}
+
+// RichTextDateTime https://core.telegram.org/bots/api#richtextdatetime
+type RichTextDateTime struct {
+	Type           RichTextType `json:"type"`
+	Text           RichText     `json:"text"`
+	UnixTime       int64        `json:"unix_time"`
+	DateTimeFormat string       `json:"date_time_format"`
+}
+
+// RichTextTextMention https://core.telegram.org/bots/api#richtexttextmention
+type RichTextTextMention struct {
+	Type RichTextType `json:"type"`
+	Text RichText     `json:"text"`
+	User User         `json:"user"`
+}
+
+// RichTextSubscript https://core.telegram.org/bots/api#richtextsubscript
+type RichTextSubscript struct {
+	Type RichTextType `json:"type"`
+	Text RichText     `json:"text"`
+}
+
+// RichTextSuperscript https://core.telegram.org/bots/api#richtextsuperscript
+type RichTextSuperscript struct {
+	Type RichTextType `json:"type"`
+	Text RichText     `json:"text"`
+}
+
+// RichTextMarked https://core.telegram.org/bots/api#richtextmarked
+type RichTextMarked struct {
+	Type RichTextType `json:"type"`
+	Text RichText     `json:"text"`
+}
+
+// RichTextCode https://core.telegram.org/bots/api#richtextcode
+type RichTextCode struct {
+	Type RichTextType `json:"type"`
+	Text RichText     `json:"text"`
+}
+
+// RichTextCustomEmoji https://core.telegram.org/bots/api#richtextcustomemoji
+type RichTextCustomEmoji struct {
+	Type            RichTextType `json:"type"`
+	CustomEmojiID   string       `json:"custom_emoji_id"`
+	AlternativeText string       `json:"alternative_text"`
+}
+
+// RichTextMathematicalExpression https://core.telegram.org/bots/api#richtextmathematicalexpression
+type RichTextMathematicalExpression struct {
+	Type       RichTextType `json:"type"`
+	Expression string       `json:"expression"`
+}
+
+// RichTextURL https://core.telegram.org/bots/api#richtexturl
+type RichTextURL struct {
+	Type RichTextType `json:"type"`
+	Text RichText     `json:"text"`
+	URL  string       `json:"url"`
+}
+
+// RichTextEmailAddress https://core.telegram.org/bots/api#richtextemailaddress
+type RichTextEmailAddress struct {
+	Type         RichTextType `json:"type"`
+	Text         RichText     `json:"text"`
+	EmailAddress string       `json:"email_address"`
+}
+
+// RichTextPhoneNumber https://core.telegram.org/bots/api#richtextphonenumber
+type RichTextPhoneNumber struct {
+	Type        RichTextType `json:"type"`
+	Text        RichText     `json:"text"`
+	PhoneNumber string       `json:"phone_number"`
+}
+
+// RichTextBankCardNumber https://core.telegram.org/bots/api#richtextbankcardnumber
+type RichTextBankCardNumber struct {
+	Type           RichTextType `json:"type"`
+	Text           RichText     `json:"text"`
+	BankCardNumber string       `json:"bank_card_number"`
+}
+
+// RichTextMention https://core.telegram.org/bots/api#richtextmention
+type RichTextMention struct {
+	Type     RichTextType `json:"type"`
+	Text     RichText     `json:"text"`
+	Username string       `json:"username"`
+}
+
+// RichTextHashtag https://core.telegram.org/bots/api#richtexthashtag
+type RichTextHashtag struct {
+	Type    RichTextType `json:"type"`
+	Text    RichText     `json:"text"`
+	Hashtag string       `json:"hashtag"`
+}
+
+// RichTextCashtag https://core.telegram.org/bots/api#richtextcashtag
+type RichTextCashtag struct {
+	Type    RichTextType `json:"type"`
+	Text    RichText     `json:"text"`
+	Cashtag string       `json:"cashtag"`
+}
+
+// RichTextBotCommand https://core.telegram.org/bots/api#richtextbotcommand
+type RichTextBotCommand struct {
+	Type       RichTextType `json:"type"`
+	Text       RichText     `json:"text"`
+	BotCommand string       `json:"bot_command"`
+}
+
+// RichTextAnchor https://core.telegram.org/bots/api#richtextanchor
+type RichTextAnchor struct {
+	Type RichTextType `json:"type"`
+	Name string       `json:"name"`
+}
+
+// RichTextAnchorLink https://core.telegram.org/bots/api#richtextanchorlink
+type RichTextAnchorLink struct {
+	Type       RichTextType `json:"type"`
+	Text       RichText     `json:"text"`
+	AnchorName string       `json:"anchor_name"`
+}
+
+// RichTextReference https://core.telegram.org/bots/api#richtextreference
+type RichTextReference struct {
+	Type RichTextType `json:"type"`
+	Text RichText     `json:"text"`
+	Name string       `json:"name"`
+}
+
+// RichTextReferenceLink https://core.telegram.org/bots/api#richtextreferencelink
+type RichTextReferenceLink struct {
+	Type          RichTextType `json:"type"`
+	Text          RichText     `json:"text"`
+	ReferenceName string       `json:"reference_name"`
+}
+
+// RichBlockCaption https://core.telegram.org/bots/api#richblockcaption
+type RichBlockCaption struct {
+	Text   RichText  `json:"text"`
+	Credit *RichText `json:"credit,omitempty"`
+}
+
+// RichBlockTableCell https://core.telegram.org/bots/api#richblocktablecell
+type RichBlockTableCell struct {
+	Text     *RichText `json:"text,omitempty"`
+	IsHeader bool      `json:"is_header,omitempty"`
+	Colspan  int       `json:"colspan,omitempty"`
+	Rowspan  int       `json:"rowspan,omitempty"`
+	Align    string    `json:"align"`
+	VAlign   string    `json:"valign"`
+}
+
+// RichBlockListItem https://core.telegram.org/bots/api#richblocklistitem
+type RichBlockListItem struct {
+	Label       string      `json:"label"`
+	Blocks      []RichBlock `json:"blocks"`
+	HasCheckbox bool        `json:"has_checkbox,omitempty"`
+	IsChecked   bool        `json:"is_checked,omitempty"`
+	Value       int         `json:"value,omitempty"`
+	Type        string      `json:"type,omitempty"`
+}
+
+// RichBlockType https://core.telegram.org/bots/api#richblock
+type RichBlockType string
+
+const (
+	RichBlockTypeParagraph              RichBlockType = "paragraph"
+	RichBlockTypeHeading                RichBlockType = "heading"
+	RichBlockTypePre                    RichBlockType = "pre"
+	RichBlockTypeFooter                 RichBlockType = "footer"
+	RichBlockTypeDivider                RichBlockType = "divider"
+	RichBlockTypeMathematicalExpression RichBlockType = "mathematical_expression"
+	RichBlockTypeAnchor                 RichBlockType = "anchor"
+	RichBlockTypeList                   RichBlockType = "list"
+	RichBlockTypeBlockquote             RichBlockType = "blockquote"
+	RichBlockTypePullquote              RichBlockType = "pullquote"
+	RichBlockTypeCollage                RichBlockType = "collage"
+	RichBlockTypeSlideshow              RichBlockType = "slideshow"
+	RichBlockTypeTable                  RichBlockType = "table"
+	RichBlockTypeDetails                RichBlockType = "details"
+	RichBlockTypeMap                    RichBlockType = "map"
+	RichBlockTypeAnimation              RichBlockType = "animation"
+	RichBlockTypeAudio                  RichBlockType = "audio"
+	RichBlockTypePhoto                  RichBlockType = "photo"
+	RichBlockTypeVideo                  RichBlockType = "video"
+	RichBlockTypeVoiceNote              RichBlockType = "voice_note"
+	RichBlockTypeThinking               RichBlockType = "thinking"
+)
+
+// RichBlock https://core.telegram.org/bots/api#richblock
+//
+// Represents a block in a rich formatted message.
+type RichBlock struct {
+	Type RichBlockType
+
+	Paragraph              *RichBlockParagraph
+	SectionHeading         *RichBlockSectionHeading
+	Preformatted           *RichBlockPreformatted
+	Footer                 *RichBlockFooter
+	Divider                *RichBlockDivider
+	MathematicalExpression *RichBlockMathematicalExpression
+	Anchor                 *RichBlockAnchor
+	List                   *RichBlockList
+	BlockQuotation         *RichBlockBlockQuotation
+	PullQuotation          *RichBlockPullQuotation
+	Collage                *RichBlockCollage
+	Slideshow              *RichBlockSlideshow
+	Table                  *RichBlockTable
+	Details                *RichBlockDetails
+	Map                    *RichBlockMap
+	Animation              *RichBlockAnimation
+	Audio                  *RichBlockAudio
+	Photo                  *RichBlockPhoto
+	Video                  *RichBlockVideo
+	VoiceNote              *RichBlockVoiceNote
+	Thinking               *RichBlockThinking
+}
+
+func (b RichBlock) MarshalJSON() ([]byte, error) {
+	switch b.Type {
+	case RichBlockTypeParagraph:
+		b.Paragraph.Type = RichBlockTypeParagraph
+		return json.Marshal(b.Paragraph)
+	case RichBlockTypeHeading:
+		b.SectionHeading.Type = RichBlockTypeHeading
+		return json.Marshal(b.SectionHeading)
+	case RichBlockTypePre:
+		b.Preformatted.Type = RichBlockTypePre
+		return json.Marshal(b.Preformatted)
+	case RichBlockTypeFooter:
+		b.Footer.Type = RichBlockTypeFooter
+		return json.Marshal(b.Footer)
+	case RichBlockTypeDivider:
+		b.Divider.Type = RichBlockTypeDivider
+		return json.Marshal(b.Divider)
+	case RichBlockTypeMathematicalExpression:
+		b.MathematicalExpression.Type = RichBlockTypeMathematicalExpression
+		return json.Marshal(b.MathematicalExpression)
+	case RichBlockTypeAnchor:
+		b.Anchor.Type = RichBlockTypeAnchor
+		return json.Marshal(b.Anchor)
+	case RichBlockTypeList:
+		b.List.Type = RichBlockTypeList
+		return json.Marshal(b.List)
+	case RichBlockTypeBlockquote:
+		b.BlockQuotation.Type = RichBlockTypeBlockquote
+		return json.Marshal(b.BlockQuotation)
+	case RichBlockTypePullquote:
+		b.PullQuotation.Type = RichBlockTypePullquote
+		return json.Marshal(b.PullQuotation)
+	case RichBlockTypeCollage:
+		b.Collage.Type = RichBlockTypeCollage
+		return json.Marshal(b.Collage)
+	case RichBlockTypeSlideshow:
+		b.Slideshow.Type = RichBlockTypeSlideshow
+		return json.Marshal(b.Slideshow)
+	case RichBlockTypeTable:
+		b.Table.Type = RichBlockTypeTable
+		return json.Marshal(b.Table)
+	case RichBlockTypeDetails:
+		b.Details.Type = RichBlockTypeDetails
+		return json.Marshal(b.Details)
+	case RichBlockTypeMap:
+		b.Map.Type = RichBlockTypeMap
+		return json.Marshal(b.Map)
+	case RichBlockTypeAnimation:
+		b.Animation.Type = RichBlockTypeAnimation
+		return json.Marshal(b.Animation)
+	case RichBlockTypeAudio:
+		b.Audio.Type = RichBlockTypeAudio
+		return json.Marshal(b.Audio)
+	case RichBlockTypePhoto:
+		b.Photo.Type = RichBlockTypePhoto
+		return json.Marshal(b.Photo)
+	case RichBlockTypeVideo:
+		b.Video.Type = RichBlockTypeVideo
+		return json.Marshal(b.Video)
+	case RichBlockTypeVoiceNote:
+		b.VoiceNote.Type = RichBlockTypeVoiceNote
+		return json.Marshal(b.VoiceNote)
+	case RichBlockTypeThinking:
+		b.Thinking.Type = RichBlockTypeThinking
+		return json.Marshal(b.Thinking)
+	}
+
+	return nil, fmt.Errorf("unsupported RichBlock type %q", b.Type)
+}
+
+func (b *RichBlock) UnmarshalJSON(data []byte) error {
+	v := struct {
+		Type RichBlockType `json:"type"`
+	}{}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+	b.Type = v.Type
+
+	switch v.Type {
+	case RichBlockTypeParagraph:
+		b.Paragraph = &RichBlockParagraph{}
+		return json.Unmarshal(data, b.Paragraph)
+	case RichBlockTypeHeading:
+		b.SectionHeading = &RichBlockSectionHeading{}
+		return json.Unmarshal(data, b.SectionHeading)
+	case RichBlockTypePre:
+		b.Preformatted = &RichBlockPreformatted{}
+		return json.Unmarshal(data, b.Preformatted)
+	case RichBlockTypeFooter:
+		b.Footer = &RichBlockFooter{}
+		return json.Unmarshal(data, b.Footer)
+	case RichBlockTypeDivider:
+		b.Divider = &RichBlockDivider{}
+		return json.Unmarshal(data, b.Divider)
+	case RichBlockTypeMathematicalExpression:
+		b.MathematicalExpression = &RichBlockMathematicalExpression{}
+		return json.Unmarshal(data, b.MathematicalExpression)
+	case RichBlockTypeAnchor:
+		b.Anchor = &RichBlockAnchor{}
+		return json.Unmarshal(data, b.Anchor)
+	case RichBlockTypeList:
+		b.List = &RichBlockList{}
+		return json.Unmarshal(data, b.List)
+	case RichBlockTypeBlockquote:
+		b.BlockQuotation = &RichBlockBlockQuotation{}
+		return json.Unmarshal(data, b.BlockQuotation)
+	case RichBlockTypePullquote:
+		b.PullQuotation = &RichBlockPullQuotation{}
+		return json.Unmarshal(data, b.PullQuotation)
+	case RichBlockTypeCollage:
+		b.Collage = &RichBlockCollage{}
+		return json.Unmarshal(data, b.Collage)
+	case RichBlockTypeSlideshow:
+		b.Slideshow = &RichBlockSlideshow{}
+		return json.Unmarshal(data, b.Slideshow)
+	case RichBlockTypeTable:
+		b.Table = &RichBlockTable{}
+		return json.Unmarshal(data, b.Table)
+	case RichBlockTypeDetails:
+		b.Details = &RichBlockDetails{}
+		return json.Unmarshal(data, b.Details)
+	case RichBlockTypeMap:
+		b.Map = &RichBlockMap{}
+		return json.Unmarshal(data, b.Map)
+	case RichBlockTypeAnimation:
+		b.Animation = &RichBlockAnimation{}
+		return json.Unmarshal(data, b.Animation)
+	case RichBlockTypeAudio:
+		b.Audio = &RichBlockAudio{}
+		return json.Unmarshal(data, b.Audio)
+	case RichBlockTypePhoto:
+		b.Photo = &RichBlockPhoto{}
+		return json.Unmarshal(data, b.Photo)
+	case RichBlockTypeVideo:
+		b.Video = &RichBlockVideo{}
+		return json.Unmarshal(data, b.Video)
+	case RichBlockTypeVoiceNote:
+		b.VoiceNote = &RichBlockVoiceNote{}
+		return json.Unmarshal(data, b.VoiceNote)
+	case RichBlockTypeThinking:
+		b.Thinking = &RichBlockThinking{}
+		return json.Unmarshal(data, b.Thinking)
+	}
+
+	return fmt.Errorf("unsupported RichBlock type %q", v.Type)
+}
+
+// RichBlockParagraph https://core.telegram.org/bots/api#richblockparagraph
+type RichBlockParagraph struct {
+	Type RichBlockType `json:"type"`
+	Text RichText      `json:"text"`
+}
+
+// RichBlockSectionHeading https://core.telegram.org/bots/api#richblocksectionheading
+type RichBlockSectionHeading struct {
+	Type RichBlockType `json:"type"`
+	Text RichText      `json:"text"`
+	Size int           `json:"size"`
+}
+
+// RichBlockPreformatted https://core.telegram.org/bots/api#richblockpreformatted
+type RichBlockPreformatted struct {
+	Type     RichBlockType `json:"type"`
+	Text     RichText      `json:"text"`
+	Language string        `json:"language,omitempty"`
+}
+
+// RichBlockFooter https://core.telegram.org/bots/api#richblockfooter
+type RichBlockFooter struct {
+	Type RichBlockType `json:"type"`
+	Text RichText      `json:"text"`
+}
+
+// RichBlockDivider https://core.telegram.org/bots/api#richblockdivider
+type RichBlockDivider struct {
+	Type RichBlockType `json:"type"`
+}
+
+// RichBlockMathematicalExpression https://core.telegram.org/bots/api#richblockmathematicalexpression
+type RichBlockMathematicalExpression struct {
+	Type       RichBlockType `json:"type"`
+	Expression string        `json:"expression"`
+}
+
+// RichBlockAnchor https://core.telegram.org/bots/api#richblockanchor
+type RichBlockAnchor struct {
+	Type RichBlockType `json:"type"`
+	Name string        `json:"name"`
+}
+
+// RichBlockList https://core.telegram.org/bots/api#richblocklist
+type RichBlockList struct {
+	Type  RichBlockType       `json:"type"`
+	Items []RichBlockListItem `json:"items"`
+}
+
+// RichBlockBlockQuotation https://core.telegram.org/bots/api#richblockblockquotation
+type RichBlockBlockQuotation struct {
+	Type   RichBlockType `json:"type"`
+	Blocks []RichBlock   `json:"blocks"`
+	Credit *RichText     `json:"credit,omitempty"`
+}
+
+// RichBlockPullQuotation https://core.telegram.org/bots/api#richblockpullquotation
+type RichBlockPullQuotation struct {
+	Type   RichBlockType `json:"type"`
+	Text   RichText      `json:"text"`
+	Credit *RichText     `json:"credit,omitempty"`
+}
+
+// RichBlockCollage https://core.telegram.org/bots/api#richblockcollage
+type RichBlockCollage struct {
+	Type    RichBlockType     `json:"type"`
+	Blocks  []RichBlock       `json:"blocks"`
+	Caption *RichBlockCaption `json:"caption,omitempty"`
+}
+
+// RichBlockSlideshow https://core.telegram.org/bots/api#richblockslideshow
+type RichBlockSlideshow struct {
+	Type    RichBlockType     `json:"type"`
+	Blocks  []RichBlock       `json:"blocks"`
+	Caption *RichBlockCaption `json:"caption,omitempty"`
+}
+
+// RichBlockTable https://core.telegram.org/bots/api#richblocktable
+type RichBlockTable struct {
+	Type       RichBlockType          `json:"type"`
+	Cells      [][]RichBlockTableCell `json:"cells"`
+	IsBordered bool                   `json:"is_bordered,omitempty"`
+	IsStriped  bool                   `json:"is_striped,omitempty"`
+	Caption    *RichText              `json:"caption,omitempty"`
+}
+
+// RichBlockDetails https://core.telegram.org/bots/api#richblockdetails
+type RichBlockDetails struct {
+	Type    RichBlockType `json:"type"`
+	Summary RichText      `json:"summary"`
+	Blocks  []RichBlock   `json:"blocks"`
+	IsOpen  bool          `json:"is_open,omitempty"`
+}
+
+// RichBlockMap https://core.telegram.org/bots/api#richblockmap
+type RichBlockMap struct {
+	Type     RichBlockType     `json:"type"`
+	Location Location          `json:"location"`
+	Zoom     int               `json:"zoom"`
+	Width    int               `json:"width"`
+	Height   int               `json:"height"`
+	Caption  *RichBlockCaption `json:"caption,omitempty"`
+}
+
+// RichBlockAnimation https://core.telegram.org/bots/api#richblockanimation
+type RichBlockAnimation struct {
+	Type       RichBlockType     `json:"type"`
+	Animation  Animation         `json:"animation"`
+	HasSpoiler bool              `json:"has_spoiler,omitempty"`
+	Caption    *RichBlockCaption `json:"caption,omitempty"`
+}
+
+// RichBlockAudio https://core.telegram.org/bots/api#richblockaudio
+type RichBlockAudio struct {
+	Type    RichBlockType     `json:"type"`
+	Audio   Audio             `json:"audio"`
+	Caption *RichBlockCaption `json:"caption,omitempty"`
+}
+
+// RichBlockPhoto https://core.telegram.org/bots/api#richblockphoto
+type RichBlockPhoto struct {
+	Type       RichBlockType     `json:"type"`
+	Photo      []PhotoSize       `json:"photo"`
+	HasSpoiler bool              `json:"has_spoiler,omitempty"`
+	Caption    *RichBlockCaption `json:"caption,omitempty"`
+}
+
+// RichBlockVideo https://core.telegram.org/bots/api#richblockvideo
+type RichBlockVideo struct {
+	Type       RichBlockType     `json:"type"`
+	Video      Video             `json:"video"`
+	HasSpoiler bool              `json:"has_spoiler,omitempty"`
+	Caption    *RichBlockCaption `json:"caption,omitempty"`
+}
+
+// RichBlockVoiceNote https://core.telegram.org/bots/api#richblockvoicenote
+type RichBlockVoiceNote struct {
+	Type      RichBlockType     `json:"type"`
+	VoiceNote Voice             `json:"voice_note"`
+	Caption   *RichBlockCaption `json:"caption,omitempty"`
+}
+
+// RichBlockThinking https://core.telegram.org/bots/api#richblockthinking
+type RichBlockThinking struct {
+	Type RichBlockType `json:"type"`
+	Text RichText      `json:"text"`
+}

--- a/models/rich_message_test.go
+++ b/models/rich_message_test.go
@@ -1,0 +1,164 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// InputRichMessageContent must be usable as InlineQueryResultArticle.InputMessageContent.
+func TestInputRichMessageContent_implementsInputMessageContent(t *testing.T) {
+	var _ InputMessageContent = InputRichMessageContent{}
+	var _ InputMessageContent = &InputRichMessageContent{}
+
+	article := &InlineQueryResultArticle{
+		ID:           "share_1",
+		Title:        "Title",
+		Description:  "Description",
+		ThumbnailURL: "https://cdn.example.com/thumb.jpg",
+		InputMessageContent: &InputRichMessageContent{
+			RichMessage: InputRichMessage{
+				Markdown: "# Title\n\nDescription",
+			},
+		},
+	}
+
+	if article.InputMessageContent == nil {
+		t.Fatal("InputMessageContent is nil")
+	}
+}
+
+func TestInputRichMessageContent_marshalJSON(t *testing.T) {
+	c := InputRichMessageContent{
+		RichMessage: InputRichMessage{
+			Markdown:            "# Title\n\nDescription\n\n![](https://cdn.example.com/photo.jpg)",
+			IsRTL:               true,
+			SkipEntityDetection: true,
+		},
+	}
+
+	data, err := json.Marshal(c)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := string(data)
+	expect := `{"rich_message":{"markdown":"# Title\n\nDescription\n\n![](https://cdn.example.com/photo.jpg)","is_rtl":true,"skip_entity_detection":true}}`
+	if got != expect {
+		t.Fatalf("unexpected json\n got: %s\nwant: %s", got, expect)
+	}
+}
+
+func TestInputRichMessage_marshalOmitEmpty(t *testing.T) {
+	data, err := json.Marshal(InputRichMessage{Markdown: "**hi**"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != `{"markdown":"**hi**"}` {
+		t.Fatalf("unexpected json: %s", string(data))
+	}
+}
+
+// Message.rich_message must deserialize, including typed rich text and rich blocks.
+func TestMessage_unmarshalRichMessage(t *testing.T) {
+	src := `{
+		"message_id": 1,
+		"date": 0,
+		"chat": {"id": 42},
+		"rich_message": {
+			"is_rtl": false,
+			"blocks": [
+				{"type": "heading", "size": 1, "text": "Report"},
+				{"type": "paragraph", "text": [
+					"intro ",
+					{"type": "bold", "text": "bold"},
+					{"type": "url", "text": "link", "url": "https://t.me/"}
+				]},
+				{"type": "divider"},
+				{"type": "photo", "photo": [{"file_id": "abc", "file_unique_id": "u", "width": 100, "height": 200}], "caption": {"text": "cap"}}
+			]
+		}
+	}`
+
+	msg := Message{}
+	if err := json.Unmarshal([]byte(src), &msg); err != nil {
+		t.Fatal(err)
+	}
+
+	if msg.RichMessage == nil {
+		t.Fatal("RichMessage is nil")
+	}
+	if len(msg.RichMessage.Blocks) != 4 {
+		t.Fatalf("expected 4 blocks, got %d", len(msg.RichMessage.Blocks))
+	}
+
+	heading := msg.RichMessage.Blocks[0]
+	if heading.Type != RichBlockTypeHeading || heading.SectionHeading == nil {
+		t.Fatal("first block is not a heading")
+	}
+	if heading.SectionHeading.Size != 1 {
+		t.Fatalf("unexpected heading size: %d", heading.SectionHeading.Size)
+	}
+	if heading.SectionHeading.Text.Plain == nil || *heading.SectionHeading.Text.Plain != "Report" {
+		t.Fatal("unexpected heading text")
+	}
+
+	paragraph := msg.RichMessage.Blocks[1]
+	if paragraph.Type != RichBlockTypeParagraph || paragraph.Paragraph == nil {
+		t.Fatal("second block is not a paragraph")
+	}
+	arr := paragraph.Paragraph.Text.Array
+	if len(arr) != 3 {
+		t.Fatalf("expected 3 rich text parts, got %d", len(arr))
+	}
+	if arr[1].Type != RichTextTypeBold || arr[1].Bold == nil {
+		t.Fatal("second part is not bold")
+	}
+	if arr[2].Type != RichTextTypeURL || arr[2].URL == nil || arr[2].URL.URL != "https://t.me/" {
+		t.Fatal("third part is not a url")
+	}
+
+	if msg.RichMessage.Blocks[2].Type != RichBlockTypeDivider {
+		t.Fatal("third block is not a divider")
+	}
+
+	photo := msg.RichMessage.Blocks[3]
+	if photo.Type != RichBlockTypePhoto || photo.Photo == nil {
+		t.Fatal("fourth block is not a photo")
+	}
+	if len(photo.Photo.Photo) != 1 || photo.Photo.Photo[0].FileID != "abc" {
+		t.Fatal("unexpected photo content")
+	}
+	if photo.Photo.Caption == nil || photo.Photo.Caption.Text.Plain == nil || *photo.Photo.Caption.Text.Plain != "cap" {
+		t.Fatal("unexpected photo caption")
+	}
+}
+
+func TestRichBlock_roundTrip(t *testing.T) {
+	src := `{"type":"paragraph","text":[{"type":"bold","text":"x"},{"type":"italic","text":"y"}]}`
+
+	block := RichBlock{}
+	if err := json.Unmarshal([]byte(src), &block); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := json.Marshal(block)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != src {
+		t.Fatalf("round trip mismatch\n got: %s\nwant: %s", string(data), src)
+	}
+}
+
+// Existing input message content types must keep working.
+func TestInputTextMessageContent_stillWorks(t *testing.T) {
+	var _ InputMessageContent = &InputTextMessageContent{}
+
+	data, err := json.Marshal(&InputTextMessageContent{MessageText: "hello"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != `{"message_text":"hello"}` {
+		t.Fatalf("unexpected json: %s", string(data))
+	}
+}


### PR DESCRIPTION
## Summary

This PR adds Telegram Bot API 10.1 Rich Messages support.

The main goal is to support rich message content in inline query results, especially this use case:

* Return `InlineQueryResultArticle` in inline query results
* Show `title`, `description`, and `thumbnail_url` in the inline candidate list
* Send rich structured content after selection
* Avoid using the Article `url` field
* Avoid showing media URLs directly in the message body

## What changed

* Added Rich Message related models/types for Bot API 10.1
* Added `InputRichMessageContent` support for inline query `input_message_content`
* Added `Message.rich_message` support
* Added API wrappers for Rich Message related methods
* Added an inline rich message example
* Added tests for Rich Message serialization/deserialization and inline query usage
* Updated Bot API support documentation from 10.0 to 10.1

## Why

Telegram Bot API 10.1 introduced Rich Messages, which allow bots to send structured rich content. This is especially useful for inline query scenarios where the result list should show an article-style preview, while the selected result sends rich content containing text and media.

Without this support, users need to either:

* Use `InlineQueryResultPhoto`, which does not reliably show title/description in some Telegram clients
* Use `InlineQueryResultArticle` with plain text content only
* Fall back to raw JSON calls for `answerInlineQuery`

This PR makes Rich Message support available through the typed Go API.

## Compatibility

This change is intended to be additive and should not break existing inline query result types or existing `InputMessageContent` implementations.

Existing types such as:

* `InputTextMessageContent`
* `InlineQueryResultArticle`
* `InlineQueryResultPhoto`
* `InlineQueryResultCachedPhoto`

should continue to work as before.

## Testing

I ran:

```bash
go generate ./...
gofmt -w .
go test ./...
go vet ./...
```

Please see the latest CI result for full validation.
