### PR TITLE
fix: correct reply_to_story field name and json tag on Message

### DIFF
--- a/models/message.go
+++ b/models/message.go
@@ -97,7 +97,7 @@ type Message struct {
 	ReplyToMessage                *Message                       `json:"reply_to_message,omitempty"`
 	ExternalReply                 *ExternalReplyInfo             `json:"external_reply,omitempty"`
 	Quote                         *TextQuote                     `json:"quote,omitempty"`
-	ReplyToStore                  *Story                         `json:"reply_to_store,omitempty"`
+	ReplyToStory                  *Story                         `json:"reply_to_story,omitempty"`
 	ReplyToChecklistTaskID        int                            `json:"reply_to_checklist_task_id,omitempty"`
 	ViaBot                        *User                          `json:"via_bot,omitempty"`
 	EditDate                      int                            `json:"edit_date,omitempty"`

--- a/models/message_test.go
+++ b/models/message_test.go
@@ -1,6 +1,9 @@
 package models
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+)
 
 func TestUnmarshalMaybeInaccessibleMessage_inaccessible(t *testing.T) {
 	src := `{"date":0,"chat":{"id":123},"message_id":987}`
@@ -51,5 +54,26 @@ func TestUnmarshalMaybeInaccessibleMessage_message(t *testing.T) {
 
 	if mim.Message.ID != 987 {
 		t.Fatal("wrong message id")
+	}
+}
+
+func TestUnmarshalMessage_replyToStory(t *testing.T) {
+	src := `{"date":0,"chat":{"id":123},"message_id":987,"reply_to_story":{"chat":{"id":42},"id":7}}`
+
+	msg := Message{}
+	if err := json.Unmarshal([]byte(src), &msg); err != nil {
+		t.Fatal(err)
+	}
+
+	if msg.ReplyToStory == nil {
+		t.Fatal("ReplyToStory is nil")
+	}
+
+	if msg.ReplyToStory.ID != 7 {
+		t.Fatal("wrong story id")
+	}
+
+	if msg.ReplyToStory.Chat.ID != 42 {
+		t.Fatal("wrong story chat id")
 	}
 }


### PR DESCRIPTION
### Problem

`Message.ReplyToStore` is declared with a `json:"reply_to_store"` tag — a typo of the Bot API field, which is [`reply_to_story`](https://core.telegram.org/bots/api#message) (a `Story` sent in reply to a story). Because the tag doesn't match, Telegram's `reply_to_story` is never unmarshalled and the field is always `nil`.

### Fix

- Rename the field `ReplyToStore` → `ReplyToStory` and fix the tag to `reply_to_story`.
- Add an unmarshal test covering the field.

The field isn't referenced anywhere else in the library, and it never populated before, so nothing depended on the old (typo) name.

### Verification

- `gofmt` clean, `go vet ./models/` clean.
- `go test ./models/` passes, including the new `TestUnmarshalMessage_replyToStory`.