### PR TITLE
Support Bot API 10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@
     on `ChatFullInfo`.
   - General: new `BotSubscriptionUpdated` with the `subscription` field on
     `Update` (and `subscription` allowed-update constant).
+- Fix: `InputMedia` values now implement `json.Marshaler`, so the required `type`
+  discriminator is kept when they are encoded through a plain `json.Marshal`
+  (e.g. nested inside a rich message). Previously `type` was only emitted by
+  `MarshalInputMedia`, which nested values never reached.
+- Fix: `InputRichBlock.MarshalJSON` returns an error instead of panicking when
+  `Type` is set without its matching variant pointer.
 
 ## v1.22.0 (2026-06-30)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## v1.23.0 (2026-07-20)
+
+- Support Bot API 10.2 (July 14, 2026 update):
+  - Rich Messages: new `InputRichMessageMedia`, `InputMediaVoiceNote`, the 21
+    `InputRichBlock*` block types (via the `InputRichBlock` tagged union) and
+    `InputRichBlockListItem`; added `blocks` and `media` fields to
+    `InputRichMessage`.
+  - Ephemeral Messages: new methods `editEphemeralMessageText`,
+    `editEphemeralMessageMedia`, `editEphemeralMessageCaption`,
+    `editEphemeralMessageReplyMarkup`, `deleteEphemeralMessage`; added
+    `receiver_user_id` and `callback_query_id` params to the 13 send methods;
+    `is_ephemeral` on `BotCommand`; `receiver_user` and `ephemeral_message_id`
+    on `Message`; `ephemeral_message_id` on `ReplyParameters` (and `message_id`
+    made optional).
+  - Communities: new `Community`, `CommunityChatAdded`, `CommunityChatRemoved`;
+    `community_chat_added` / `community_chat_removed` on `Message`; `community`
+    on `ChatFullInfo`.
+  - General: new `BotSubscriptionUpdated` with the `subscription` field on
+    `Update` (and `subscription` allowed-update constant).
+
 ## v1.22.0 (2026-06-30)
 
 - Support Bot API 10.1 (June 11, 2026 update) — Rich Messages:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 > [Telegram Group](https://t.me/gotelegrambotui)
 
-> Supports Bot API version: [10.1](https://core.telegram.org/bots/api#june-11-2026) from June 11, 2026
+> Supports Bot API version: [10.2](https://core.telegram.org/bots/api#july-14-2026) from July 14, 2026
 
 It's a Go zero-dependencies telegram bot framework
 

--- a/methods.go
+++ b/methods.go
@@ -708,6 +708,41 @@ func (b *Bot) DeleteMessages(ctx context.Context, params *DeleteMessagesParams) 
 	return result, err
 }
 
+// EditEphemeralMessageText https://core.telegram.org/bots/api#editephemeralmessagetext
+func (b *Bot) EditEphemeralMessageText(ctx context.Context, params *EditEphemeralMessageTextParams) (bool, error) {
+	var result bool
+	err := b.rawRequest(ctx, "editEphemeralMessageText", params, &result)
+	return result, err
+}
+
+// EditEphemeralMessageMedia https://core.telegram.org/bots/api#editephemeralmessagemedia
+func (b *Bot) EditEphemeralMessageMedia(ctx context.Context, params *EditEphemeralMessageMediaParams) (bool, error) {
+	var result bool
+	err := b.rawRequest(ctx, "editEphemeralMessageMedia", params, &result)
+	return result, err
+}
+
+// EditEphemeralMessageCaption https://core.telegram.org/bots/api#editephemeralmessagecaption
+func (b *Bot) EditEphemeralMessageCaption(ctx context.Context, params *EditEphemeralMessageCaptionParams) (bool, error) {
+	var result bool
+	err := b.rawRequest(ctx, "editEphemeralMessageCaption", params, &result)
+	return result, err
+}
+
+// EditEphemeralMessageReplyMarkup https://core.telegram.org/bots/api#editephemeralmessagereplymarkup
+func (b *Bot) EditEphemeralMessageReplyMarkup(ctx context.Context, params *EditEphemeralMessageReplyMarkupParams) (bool, error) {
+	var result bool
+	err := b.rawRequest(ctx, "editEphemeralMessageReplyMarkup", params, &result)
+	return result, err
+}
+
+// DeleteEphemeralMessage https://core.telegram.org/bots/api#deleteephemeralmessage
+func (b *Bot) DeleteEphemeralMessage(ctx context.Context, params *DeleteEphemeralMessageParams) (bool, error) {
+	var result bool
+	err := b.rawRequest(ctx, "deleteEphemeralMessage", params, &result)
+	return result, err
+}
+
 // SendSticker https://core.telegram.org/bots/api#sendsticker
 func (b *Bot) SendSticker(ctx context.Context, params *SendStickerParams) (*models.Message, error) {
 	result := &models.Message{}

--- a/methods_params.go
+++ b/methods_params.go
@@ -24,6 +24,8 @@ type SendMessageParams struct {
 	ChatID                  any                             `json:"chat_id"`
 	MessageThreadID         int                             `json:"message_thread_id,omitempty"`
 	DirectMessagesTopicID   int                             `json:"direct_messages_topic_id,omitempty"`
+	ReceiverUserID          int64                           `json:"receiver_user_id,omitempty"`
+	CallbackQueryID         string                          `json:"callback_query_id,omitempty"`
 	Text                    string                          `json:"text"`
 	ParseMode               models.ParseMode                `json:"parse_mode,omitempty"`
 	Entities                []models.MessageEntity          `json:"entities,omitempty"`
@@ -101,6 +103,8 @@ type SendPhotoParams struct {
 	ChatID                  any                             `json:"chat_id"`
 	MessageThreadID         int                             `json:"message_thread_id,omitempty"`
 	DirectMessagesTopicID   int                             `json:"direct_messages_topic_id,omitempty"`
+	ReceiverUserID          int64                           `json:"receiver_user_id,omitempty"`
+	CallbackQueryID         string                          `json:"callback_query_id,omitempty"`
 	Photo                   models.InputFile                `json:"photo"`
 	Caption                 string                          `json:"caption,omitempty"`
 	ParseMode               models.ParseMode                `json:"parse_mode,omitempty"`
@@ -122,6 +126,8 @@ type SendAudioParams struct {
 	ChatID                  any                             `json:"chat_id"`
 	MessageThreadID         int                             `json:"message_thread_id,omitempty"`
 	DirectMessagesTopicID   int                             `json:"direct_messages_topic_id,omitempty"`
+	ReceiverUserID          int64                           `json:"receiver_user_id,omitempty"`
+	CallbackQueryID         string                          `json:"callback_query_id,omitempty"`
 	Audio                   models.InputFile                `json:"audio"`
 	Caption                 string                          `json:"caption,omitempty"`
 	ParseMode               models.ParseMode                `json:"parse_mode,omitempty"`
@@ -145,6 +151,8 @@ type SendDocumentParams struct {
 	ChatID                      any                             `json:"chat_id"`
 	MessageThreadID             int                             `json:"message_thread_id,omitempty"`
 	DirectMessagesTopicID       int                             `json:"direct_messages_topic_id,omitempty"`
+	ReceiverUserID              int64                           `json:"receiver_user_id,omitempty"`
+	CallbackQueryID             string                          `json:"callback_query_id,omitempty"`
 	Document                    models.InputFile                `json:"document"`
 	Thumbnail                   models.InputFile                `json:"thumbnail,omitempty"`
 	Caption                     string                          `json:"caption,omitempty"`
@@ -166,6 +174,8 @@ type SendVideoParams struct {
 	ChatID                  any                             `json:"chat_id"`
 	MessageThreadID         int                             `json:"message_thread_id,omitempty"`
 	DirectMessagesTopicID   int                             `json:"direct_messages_topic_id,omitempty"`
+	ReceiverUserID          int64                           `json:"receiver_user_id,omitempty"`
+	CallbackQueryID         string                          `json:"callback_query_id,omitempty"`
 	Video                   models.InputFile                `json:"video"`
 	Duration                int                             `json:"duration,omitempty"`
 	Width                   int                             `json:"width,omitempty"`
@@ -194,6 +204,8 @@ type SendAnimationParams struct {
 	ChatID                  any                             `json:"chat_id"`
 	MessageThreadID         int                             `json:"message_thread_id,omitempty"`
 	DirectMessagesTopicID   int                             `json:"direct_messages_topic_id,omitempty"`
+	ReceiverUserID          int64                           `json:"receiver_user_id,omitempty"`
+	CallbackQueryID         string                          `json:"callback_query_id,omitempty"`
 	Animation               models.InputFile                `json:"animation"`
 	Duration                int                             `json:"duration,omitempty"`
 	Width                   int                             `json:"width,omitempty"`
@@ -219,6 +231,8 @@ type SendVoiceParams struct {
 	ChatID                  any                             `json:"chat_id"`
 	MessageThreadID         int                             `json:"message_thread_id,omitempty"`
 	DirectMessagesTopicID   int                             `json:"direct_messages_topic_id,omitempty"`
+	ReceiverUserID          int64                           `json:"receiver_user_id,omitempty"`
+	CallbackQueryID         string                          `json:"callback_query_id,omitempty"`
 	Voice                   models.InputFile                `json:"voice"`
 	Caption                 string                          `json:"caption,omitempty"`
 	ParseMode               models.ParseMode                `json:"parse_mode,omitempty"`
@@ -239,6 +253,8 @@ type SendVideoNoteParams struct {
 	ChatID                  any                             `json:"chat_id"`
 	MessageThreadID         int                             `json:"message_thread_id,omitempty"`
 	DirectMessagesTopicID   int                             `json:"direct_messages_topic_id,omitempty"`
+	ReceiverUserID          int64                           `json:"receiver_user_id,omitempty"`
+	CallbackQueryID         string                          `json:"callback_query_id,omitempty"`
 	VideoNote               models.InputFile                `json:"video_note"`
 	Duration                int                             `json:"duration,omitempty"`
 	Length                  int                             `json:"length,omitempty"`
@@ -293,6 +309,8 @@ type SendLocationParams struct {
 	ChatID                  any                             `json:"chat_id"`
 	MessageThreadID         int                             `json:"message_thread_id,omitempty"`
 	DirectMessagesTopicID   int                             `json:"direct_messages_topic_id,omitempty"`
+	ReceiverUserID          int64                           `json:"receiver_user_id,omitempty"`
+	CallbackQueryID         string                          `json:"callback_query_id,omitempty"`
 	Latitude                float64                         `json:"latitude"`
 	Longitude               float64                         `json:"longitude"`
 	HorizontalAccuracy      float64                         `json:"horizontal_accuracy,omitempty"`
@@ -336,6 +354,8 @@ type SendVenueParams struct {
 	ChatID                  any                             `json:"chat_id"`
 	MessageThreadID         int                             `json:"message_thread_id,omitempty"`
 	DirectMessagesTopicID   int                             `json:"direct_messages_topic_id,omitempty"`
+	ReceiverUserID          int64                           `json:"receiver_user_id,omitempty"`
+	CallbackQueryID         string                          `json:"callback_query_id,omitempty"`
 	Latitude                float64                         `json:"latitude"`
 	Longitude               float64                         `json:"longitude"`
 	Title                   string                          `json:"title"`
@@ -359,6 +379,8 @@ type SendContactParams struct {
 	ChatID                  any                             `json:"chat_id"`
 	MessageThreadID         int                             `json:"message_thread_id,omitempty"`
 	DirectMessagesTopicID   int                             `json:"direct_messages_topic_id,omitempty"`
+	ReceiverUserID          int64                           `json:"receiver_user_id,omitempty"`
+	CallbackQueryID         string                          `json:"callback_query_id,omitempty"`
 	PhoneNumber             string                          `json:"phone_number"`
 	FirstName               string                          `json:"first_name"`
 	LastName                string                          `json:"last_name,omitempty"`
@@ -875,12 +897,61 @@ type DeleteMessagesParams struct {
 	MessageIDs []int `json:"message_ids"`
 }
 
+// EditEphemeralMessageTextParams https://core.telegram.org/bots/api#editephemeralmessagetext
+type EditEphemeralMessageTextParams struct {
+	ChatID             any                          `json:"chat_id"`
+	ReceiverUserID     int64                        `json:"receiver_user_id"`
+	EphemeralMessageID int                          `json:"ephemeral_message_id"`
+	Text               string                       `json:"text"`
+	ParseMode          models.ParseMode             `json:"parse_mode,omitempty"`
+	Entities           []models.MessageEntity       `json:"entities,omitempty"`
+	LinkPreviewOptions *models.LinkPreviewOptions   `json:"link_preview_options,omitempty"`
+	ReplyMarkup        *models.InlineKeyboardMarkup `json:"reply_markup,omitempty"`
+}
+
+// EditEphemeralMessageMediaParams https://core.telegram.org/bots/api#editephemeralmessagemedia
+type EditEphemeralMessageMediaParams struct {
+	ChatID             any                          `json:"chat_id"`
+	ReceiverUserID     int64                        `json:"receiver_user_id"`
+	EphemeralMessageID int                          `json:"ephemeral_message_id"`
+	Media              models.InputMedia            `json:"media"`
+	ReplyMarkup        *models.InlineKeyboardMarkup `json:"reply_markup,omitempty"`
+}
+
+// EditEphemeralMessageCaptionParams https://core.telegram.org/bots/api#editephemeralmessagecaption
+type EditEphemeralMessageCaptionParams struct {
+	ChatID             any                          `json:"chat_id"`
+	ReceiverUserID     int64                        `json:"receiver_user_id"`
+	EphemeralMessageID int                          `json:"ephemeral_message_id"`
+	Caption            string                       `json:"caption,omitempty"`
+	ParseMode          models.ParseMode             `json:"parse_mode,omitempty"`
+	CaptionEntities    []models.MessageEntity       `json:"caption_entities,omitempty"`
+	ReplyMarkup        *models.InlineKeyboardMarkup `json:"reply_markup,omitempty"`
+}
+
+// EditEphemeralMessageReplyMarkupParams https://core.telegram.org/bots/api#editephemeralmessagereplymarkup
+type EditEphemeralMessageReplyMarkupParams struct {
+	ChatID             any                          `json:"chat_id"`
+	ReceiverUserID     int64                        `json:"receiver_user_id"`
+	EphemeralMessageID int                          `json:"ephemeral_message_id"`
+	ReplyMarkup        *models.InlineKeyboardMarkup `json:"reply_markup,omitempty"`
+}
+
+// DeleteEphemeralMessageParams https://core.telegram.org/bots/api#deleteephemeralmessage
+type DeleteEphemeralMessageParams struct {
+	ChatID             any   `json:"chat_id"`
+	ReceiverUserID     int64 `json:"receiver_user_id"`
+	EphemeralMessageID int   `json:"ephemeral_message_id"`
+}
+
 // SendStickerParams https://core.telegram.org/bots/api#sendsticker
 type SendStickerParams struct {
 	BusinessConnectionID    string                          `json:"business_connection_id,omitempty"`
 	ChatID                  any                             `json:"chat_id"`
 	MessageThreadID         int                             `json:"message_thread_id,omitempty"`
 	DirectMessagesTopicID   int                             `json:"direct_messages_topic_id,omitempty"`
+	ReceiverUserID          int64                           `json:"receiver_user_id,omitempty"`
+	CallbackQueryID         string                          `json:"callback_query_id,omitempty"`
 	Sticker                 models.InputFile                `json:"sticker"`
 	Emoji                   string                          `json:"emoji,omitempty"`
 	DisableNotification     bool                            `json:"disable_notification,omitempty"`
@@ -1410,6 +1481,8 @@ type SendLivePhotoParams struct {
 	ChatID                  any                             `json:"chat_id"`
 	MessageThreadID         int                             `json:"message_thread_id,omitempty"`
 	DirectMessagesTopicID   int                             `json:"direct_messages_topic_id,omitempty"`
+	ReceiverUserID          int64                           `json:"receiver_user_id,omitempty"`
+	CallbackQueryID         string                          `json:"callback_query_id,omitempty"`
 	LivePhoto               models.InputFile                `json:"live_photo"`
 	Photo                   models.InputFile                `json:"photo"`
 	Caption                 string                          `json:"caption,omitempty"`

--- a/methods_test.go
+++ b/methods_test.go
@@ -1423,3 +1423,92 @@ func TestBot_RichMessageMethods(t *testing.T) {
 		assertTrue(t, resp)
 	})
 }
+
+func TestBot_EphemeralMessageMethods(t *testing.T) {
+	t.Parallel()
+
+	t.Run("EditEphemeralMessageText", func(t *testing.T) {
+		c := &httpClient{t: t, resp: `true`, reqFields: map[string]string{
+			"chat_id":              "123",
+			"receiver_user_id":     "9",
+			"ephemeral_message_id": "5",
+			"text":                 "hi",
+		}}
+		b := &Bot{client: c}
+		resp, err := b.EditEphemeralMessageText(context.Background(), &EditEphemeralMessageTextParams{
+			ChatID:             123,
+			ReceiverUserID:     9,
+			EphemeralMessageID: 5,
+			Text:               "hi",
+		})
+		assertNoErr(t, err)
+		assertTrue(t, resp)
+	})
+
+	t.Run("EditEphemeralMessageCaption", func(t *testing.T) {
+		c := &httpClient{t: t, resp: `true`, reqFields: map[string]string{
+			"chat_id":              "123",
+			"receiver_user_id":     "9",
+			"ephemeral_message_id": "5",
+			"caption":              "cap",
+		}}
+		b := &Bot{client: c}
+		resp, err := b.EditEphemeralMessageCaption(context.Background(), &EditEphemeralMessageCaptionParams{
+			ChatID:             123,
+			ReceiverUserID:     9,
+			EphemeralMessageID: 5,
+			Caption:            "cap",
+		})
+		assertNoErr(t, err)
+		assertTrue(t, resp)
+	})
+
+	t.Run("EditEphemeralMessageReplyMarkup", func(t *testing.T) {
+		c := &httpClient{t: t, resp: `true`, reqFields: map[string]string{
+			"chat_id":              "123",
+			"receiver_user_id":     "9",
+			"ephemeral_message_id": "5",
+		}}
+		b := &Bot{client: c}
+		resp, err := b.EditEphemeralMessageReplyMarkup(context.Background(), &EditEphemeralMessageReplyMarkupParams{
+			ChatID:             123,
+			ReceiverUserID:     9,
+			EphemeralMessageID: 5,
+		})
+		assertNoErr(t, err)
+		assertTrue(t, resp)
+	})
+
+	t.Run("EditEphemeralMessageMedia", func(t *testing.T) {
+		c := &httpClient{t: t, resp: `true`, reqFields: map[string]string{
+			"chat_id":              "123",
+			"receiver_user_id":     "9",
+			"ephemeral_message_id": "5",
+		}}
+		b := &Bot{client: c}
+		resp, err := b.EditEphemeralMessageMedia(context.Background(), &EditEphemeralMessageMediaParams{
+			ChatID:             123,
+			ReceiverUserID:     9,
+			EphemeralMessageID: 5,
+			Media:              &models.InputMediaPhoto{Media: "file_id"},
+		})
+		assertNoErr(t, err)
+		assertTrue(t, resp)
+	})
+
+	t.Run("DeleteEphemeralMessage", func(t *testing.T) {
+		c := &httpClient{t: t, resp: `true`, reqFields: map[string]string{
+			"chat_id":              "123",
+			"receiver_user_id":     "9",
+			"ephemeral_message_id": "5",
+		}}
+		b := &Bot{client: c}
+		resp, err := b.DeleteEphemeralMessage(context.Background(), &DeleteEphemeralMessageParams{
+			ChatID:             123,
+			ReceiverUserID:     9,
+			EphemeralMessageID: 5,
+		})
+		assertNoErr(t, err)
+		assertTrue(t, resp)
+	})
+}

--- a/models/bot_command.go
+++ b/models/bot_command.go
@@ -4,6 +4,7 @@ package models
 type BotCommand struct {
 	Command     string `json:"command" rules:"min:1,max:32"`
 	Description string `json:"description" rules:"min:1,max:256"`
+	IsEphemeral bool   `json:"is_ephemeral,omitempty"`
 }
 
 // BotName https://core.telegram.org/bots/api#botname

--- a/models/chat.go
+++ b/models/chat.go
@@ -115,6 +115,7 @@ type ChatFullInfo struct {
 	LastName                           string                `json:"last_name,omitempty"`
 	IsForum                            bool                  `json:"is_forum,omitempty"`
 	IsDirectMessages                   bool                  `json:"is_direct_messages,omitempty"`
+	Community                          *Community            `json:"community,omitempty"`
 	Photo                              *ChatPhoto            `json:"photo,omitempty"`
 	ActiveUsernames                    []string              `json:"active_usernames,omitempty"`
 	Birthdate                          Birthdate             `json:"birthdate,omitempty"`

--- a/models/community.go
+++ b/models/community.go
@@ -1,0 +1,22 @@
+package models
+
+// Community https://core.telegram.org/bots/api#community
+//
+// Represents a community (a group of chats).
+type Community struct {
+	ID   int64  `json:"id"`
+	Name string `json:"name"`
+}
+
+// CommunityChatAdded https://core.telegram.org/bots/api#communitychatadded
+//
+// Describes a service message about a chat being added to a community.
+type CommunityChatAdded struct {
+	Community Community `json:"community"`
+}
+
+// CommunityChatRemoved https://core.telegram.org/bots/api#communitychatremoved
+//
+// Describes a service message about a chat being removed from a community.
+// Currently holds no information.
+type CommunityChatRemoved struct{}

--- a/models/community_test.go
+++ b/models/community_test.go
@@ -1,0 +1,90 @@
+package models
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestMessage_Community verifies the 10.2 community service messages decode.
+func TestMessage_Community(t *testing.T) {
+	src := `{"message_id":1,"date":1,"chat":{"id":1,"type":"supergroup"},"community_chat_added":{"community":{"id":555,"name":"Gophers"}}}`
+	var m Message
+	if err := json.Unmarshal([]byte(src), &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if m.CommunityChatAdded == nil {
+		t.Fatal("community_chat_added not decoded")
+	}
+	if m.CommunityChatAdded.Community.ID != 555 || m.CommunityChatAdded.Community.Name != "Gophers" {
+		t.Fatalf("bad community: %+v", m.CommunityChatAdded.Community)
+	}
+}
+
+// TestMessage_CommunityChatRemoved verifies the empty service message decodes.
+func TestMessage_CommunityChatRemoved(t *testing.T) {
+	src := `{"message_id":1,"date":1,"chat":{"id":1,"type":"supergroup"},"community_chat_removed":{}}`
+	var m Message
+	if err := json.Unmarshal([]byte(src), &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if m.CommunityChatRemoved == nil {
+		t.Fatal("community_chat_removed not decoded")
+	}
+}
+
+// TestMessage_Ephemeral verifies the ephemeral fields on Message.
+func TestMessage_Ephemeral(t *testing.T) {
+	src := `{"message_id":1,"date":1,"chat":{"id":1,"type":"supergroup"},"receiver_user":{"id":9,"is_bot":false,"first_name":"A"},"ephemeral_message_id":77}`
+	var m Message
+	if err := json.Unmarshal([]byte(src), &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if m.ReceiverUser == nil || m.ReceiverUser.ID != 9 {
+		t.Fatalf("receiver_user not decoded: %+v", m.ReceiverUser)
+	}
+	if m.EphemeralMessageID != 77 {
+		t.Fatalf("ephemeral_message_id = %d", m.EphemeralMessageID)
+	}
+}
+
+// TestBotSubscriptionUpdated verifies the new Update field.
+func TestBotSubscriptionUpdated(t *testing.T) {
+	src := `{"update_id":1,"subscription":{"user":{"id":5,"is_bot":false,"first_name":"B"},"invoice_payload":"payload","state":"active"}}`
+	var u Update
+	if err := json.Unmarshal([]byte(src), &u); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if u.Subscription == nil || u.Subscription.State != "active" {
+		t.Fatalf("subscription not decoded: %+v", u.Subscription)
+	}
+}
+
+// TestBotCommand_IsEphemeral verifies the new BotCommand field marshals.
+func TestBotCommand_IsEphemeral(t *testing.T) {
+	out, err := json.Marshal(BotCommand{Command: "secret", Description: "d", IsEphemeral: true})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var back map[string]any
+	_ = json.Unmarshal(out, &back)
+	if back["is_ephemeral"] != true {
+		t.Fatalf("is_ephemeral not set: %s", out)
+	}
+}
+
+// TestReplyParameters_Ephemeral verifies ephemeral reply support and that
+// message_id is now omitted when zero.
+func TestReplyParameters_Ephemeral(t *testing.T) {
+	out, err := json.Marshal(ReplyParameters{EphemeralMessageID: 42})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	s := string(out)
+	if want := `"ephemeral_message_id":42`; !strings.Contains(s, want) {
+		t.Fatalf("missing %s in %s", want, s)
+	}
+	if strings.Contains(s, `"message_id"`) {
+		t.Fatalf("message_id should be omitted when zero: %s", s)
+	}
+}

--- a/models/input_media.go
+++ b/models/input_media.go
@@ -157,6 +157,37 @@ func (m InputMediaAudio) MarshalInputMedia() ([]byte, error) {
 
 func (InputMediaAudio) inputMediaTag() {}
 
+// InputMediaVoiceNote https://core.telegram.org/bots/api#inputmediavoicenote
+type InputMediaVoiceNote struct {
+	Media           string          `json:"media"`
+	Caption         string          `json:"caption,omitempty"`
+	ParseMode       ParseMode       `json:"parse_mode,omitempty"`
+	CaptionEntities []MessageEntity `json:"caption_entities,omitempty"`
+	Duration        int             `json:"duration,omitempty"`
+
+	MediaAttachment io.Reader `json:"-"`
+}
+
+func (m *InputMediaVoiceNote) Attachment() io.Reader {
+	return m.MediaAttachment
+}
+
+func (m *InputMediaVoiceNote) GetMedia() string {
+	return m.Media
+}
+
+func (m InputMediaVoiceNote) MarshalInputMedia() ([]byte, error) {
+	return json.Marshal(&struct {
+		Type string `json:"type"`
+		InputMediaVoiceNote
+	}{
+		Type:                "voice_note",
+		InputMediaVoiceNote: m,
+	})
+}
+
+func (InputMediaVoiceNote) inputMediaTag() {}
+
 // InputMediaDocument https://core.telegram.org/bots/api#inputmediadocument
 type InputMediaDocument struct {
 	Media                       string          `json:"media"`

--- a/models/input_media.go
+++ b/models/input_media.go
@@ -34,16 +34,24 @@ func (m *InputMediaPhoto) GetMedia() string {
 	return m.Media
 }
 
-func (m *InputMediaPhoto) MarshalInputMedia() ([]byte, error) {
-	ret := struct {
-		Type string `json:"type"`
-		*InputMediaPhoto
-	}{
-		Type:            "photo",
-		InputMediaPhoto: m,
-	}
+// inputMediaPhotoAlias strips the methods of InputMediaPhoto so the embedded value below is
+// encoded as plain fields instead of recursing back into MarshalJSON.
+type inputMediaPhotoAlias InputMediaPhoto
 
-	return json.Marshal(&ret)
+func (m InputMediaPhoto) MarshalInputMedia() ([]byte, error) {
+	return json.Marshal(struct {
+		Type string `json:"type"`
+		inputMediaPhotoAlias
+	}{
+		Type:                 "photo",
+		inputMediaPhotoAlias: inputMediaPhotoAlias(m),
+	})
+}
+
+// MarshalJSON keeps the required "type" discriminator when the value is reached
+// through a plain json.Marshal, e.g. nested inside a rich message.
+func (m InputMediaPhoto) MarshalJSON() ([]byte, error) {
+	return m.MarshalInputMedia()
 }
 
 func (InputMediaPhoto) inputMediaTag() {}
@@ -75,14 +83,24 @@ func (m *InputMediaVideo) GetMedia() string {
 	return m.Media
 }
 
+// inputMediaVideoAlias strips the methods of InputMediaVideo so the embedded value below is
+// encoded as plain fields instead of recursing back into MarshalJSON.
+type inputMediaVideoAlias InputMediaVideo
+
 func (m InputMediaVideo) MarshalInputMedia() ([]byte, error) {
-	return json.Marshal(&struct {
+	return json.Marshal(struct {
 		Type string `json:"type"`
-		InputMediaVideo
+		inputMediaVideoAlias
 	}{
-		Type:            "video",
-		InputMediaVideo: m,
+		Type:                 "video",
+		inputMediaVideoAlias: inputMediaVideoAlias(m),
 	})
+}
+
+// MarshalJSON keeps the required "type" discriminator when the value is reached
+// through a plain json.Marshal, e.g. nested inside a rich message.
+func (m InputMediaVideo) MarshalJSON() ([]byte, error) {
+	return m.MarshalInputMedia()
 }
 
 func (InputMediaVideo) inputMediaTag() {}
@@ -111,14 +129,24 @@ func (m *InputMediaAnimation) GetMedia() string {
 	return m.Media
 }
 
+// inputMediaAnimationAlias strips the methods of InputMediaAnimation so the embedded value below is
+// encoded as plain fields instead of recursing back into MarshalJSON.
+type inputMediaAnimationAlias InputMediaAnimation
+
 func (m InputMediaAnimation) MarshalInputMedia() ([]byte, error) {
-	return json.Marshal(&struct {
+	return json.Marshal(struct {
 		Type string `json:"type"`
-		InputMediaAnimation
+		inputMediaAnimationAlias
 	}{
-		Type:                "animation",
-		InputMediaAnimation: m,
+		Type:                     "animation",
+		inputMediaAnimationAlias: inputMediaAnimationAlias(m),
 	})
+}
+
+// MarshalJSON keeps the required "type" discriminator when the value is reached
+// through a plain json.Marshal, e.g. nested inside a rich message.
+func (m InputMediaAnimation) MarshalJSON() ([]byte, error) {
+	return m.MarshalInputMedia()
 }
 
 func (InputMediaAnimation) inputMediaTag() {}
@@ -145,14 +173,24 @@ func (m *InputMediaAudio) GetMedia() string {
 	return m.Media
 }
 
+// inputMediaAudioAlias strips the methods of InputMediaAudio so the embedded value below is
+// encoded as plain fields instead of recursing back into MarshalJSON.
+type inputMediaAudioAlias InputMediaAudio
+
 func (m InputMediaAudio) MarshalInputMedia() ([]byte, error) {
-	return json.Marshal(&struct {
+	return json.Marshal(struct {
 		Type string `json:"type"`
-		InputMediaAudio
+		inputMediaAudioAlias
 	}{
-		Type:            "audio",
-		InputMediaAudio: m,
+		Type:                 "audio",
+		inputMediaAudioAlias: inputMediaAudioAlias(m),
 	})
+}
+
+// MarshalJSON keeps the required "type" discriminator when the value is reached
+// through a plain json.Marshal, e.g. nested inside a rich message.
+func (m InputMediaAudio) MarshalJSON() ([]byte, error) {
+	return m.MarshalInputMedia()
 }
 
 func (InputMediaAudio) inputMediaTag() {}
@@ -176,14 +214,24 @@ func (m *InputMediaVoiceNote) GetMedia() string {
 	return m.Media
 }
 
+// inputMediaVoiceNoteAlias strips the methods of InputMediaVoiceNote so the embedded value below is
+// encoded as plain fields instead of recursing back into MarshalJSON.
+type inputMediaVoiceNoteAlias InputMediaVoiceNote
+
 func (m InputMediaVoiceNote) MarshalInputMedia() ([]byte, error) {
-	return json.Marshal(&struct {
+	return json.Marshal(struct {
 		Type string `json:"type"`
-		InputMediaVoiceNote
+		inputMediaVoiceNoteAlias
 	}{
-		Type:                "voice_note",
-		InputMediaVoiceNote: m,
+		Type:                     "voice_note",
+		inputMediaVoiceNoteAlias: inputMediaVoiceNoteAlias(m),
 	})
+}
+
+// MarshalJSON keeps the required "type" discriminator when the value is reached
+// through a plain json.Marshal, e.g. nested inside a rich message.
+func (m InputMediaVoiceNote) MarshalJSON() ([]byte, error) {
+	return m.MarshalInputMedia()
 }
 
 func (InputMediaVoiceNote) inputMediaTag() {}
@@ -208,14 +256,24 @@ func (m *InputMediaDocument) GetMedia() string {
 	return m.Media
 }
 
+// inputMediaDocumentAlias strips the methods of InputMediaDocument so the embedded value below is
+// encoded as plain fields instead of recursing back into MarshalJSON.
+type inputMediaDocumentAlias InputMediaDocument
+
 func (m InputMediaDocument) MarshalInputMedia() ([]byte, error) {
-	return json.Marshal(&struct {
+	return json.Marshal(struct {
 		Type string `json:"type"`
-		InputMediaDocument
+		inputMediaDocumentAlias
 	}{
-		Type:               "document",
-		InputMediaDocument: m,
+		Type:                    "document",
+		inputMediaDocumentAlias: inputMediaDocumentAlias(m),
 	})
+}
+
+// MarshalJSON keeps the required "type" discriminator when the value is reached
+// through a plain json.Marshal, e.g. nested inside a rich message.
+func (m InputMediaDocument) MarshalJSON() ([]byte, error) {
+	return m.MarshalInputMedia()
 }
 
 func (InputMediaDocument) inputMediaTag() {}
@@ -241,14 +299,24 @@ func (m *InputMediaLivePhoto) GetMedia() string {
 	return m.Media
 }
 
+// inputMediaLivePhotoAlias strips the methods of InputMediaLivePhoto so the embedded value below is
+// encoded as plain fields instead of recursing back into MarshalJSON.
+type inputMediaLivePhotoAlias InputMediaLivePhoto
+
 func (m InputMediaLivePhoto) MarshalInputMedia() ([]byte, error) {
-	return json.Marshal(&struct {
+	return json.Marshal(struct {
 		Type string `json:"type"`
-		InputMediaLivePhoto
+		inputMediaLivePhotoAlias
 	}{
-		Type:                "live_photo",
-		InputMediaLivePhoto: m,
+		Type:                     "live_photo",
+		inputMediaLivePhotoAlias: inputMediaLivePhotoAlias(m),
 	})
+}
+
+// MarshalJSON keeps the required "type" discriminator when the value is reached
+// through a plain json.Marshal, e.g. nested inside a rich message.
+func (m InputMediaLivePhoto) MarshalJSON() ([]byte, error) {
+	return m.MarshalInputMedia()
 }
 
 func (InputMediaLivePhoto) inputMediaTag() {}
@@ -268,14 +336,24 @@ func (m *InputMediaLocation) GetMedia() string {
 	return ""
 }
 
-func (m *InputMediaLocation) MarshalInputMedia() ([]byte, error) {
-	return json.Marshal(&struct {
+// inputMediaLocationAlias strips the methods of InputMediaLocation so the embedded value below is
+// encoded as plain fields instead of recursing back into MarshalJSON.
+type inputMediaLocationAlias InputMediaLocation
+
+func (m InputMediaLocation) MarshalInputMedia() ([]byte, error) {
+	return json.Marshal(struct {
 		Type string `json:"type"`
-		*InputMediaLocation
+		inputMediaLocationAlias
 	}{
-		Type:               "location",
-		InputMediaLocation: m,
+		Type:                    "location",
+		inputMediaLocationAlias: inputMediaLocationAlias(m),
 	})
+}
+
+// MarshalJSON keeps the required "type" discriminator when the value is reached
+// through a plain json.Marshal, e.g. nested inside a rich message.
+func (m InputMediaLocation) MarshalJSON() ([]byte, error) {
+	return m.MarshalInputMedia()
 }
 
 func (InputMediaLocation) inputMediaTag() {}
@@ -295,14 +373,24 @@ func (m *InputMediaSticker) GetMedia() string {
 	return m.Media
 }
 
-func (m *InputMediaSticker) MarshalInputMedia() ([]byte, error) {
-	return json.Marshal(&struct {
+// inputMediaStickerAlias strips the methods of InputMediaSticker so the embedded value below is
+// encoded as plain fields instead of recursing back into MarshalJSON.
+type inputMediaStickerAlias InputMediaSticker
+
+func (m InputMediaSticker) MarshalInputMedia() ([]byte, error) {
+	return json.Marshal(struct {
 		Type string `json:"type"`
-		*InputMediaSticker
+		inputMediaStickerAlias
 	}{
-		Type:              "sticker",
-		InputMediaSticker: m,
+		Type:                   "sticker",
+		inputMediaStickerAlias: inputMediaStickerAlias(m),
 	})
+}
+
+// MarshalJSON keeps the required "type" discriminator when the value is reached
+// through a plain json.Marshal, e.g. nested inside a rich message.
+func (m InputMediaSticker) MarshalJSON() ([]byte, error) {
+	return m.MarshalInputMedia()
 }
 
 func (InputMediaSticker) inputMediaTag() {}
@@ -327,14 +415,24 @@ func (m *InputMediaVenue) GetMedia() string {
 	return ""
 }
 
-func (m *InputMediaVenue) MarshalInputMedia() ([]byte, error) {
-	return json.Marshal(&struct {
+// inputMediaVenueAlias strips the methods of InputMediaVenue so the embedded value below is
+// encoded as plain fields instead of recursing back into MarshalJSON.
+type inputMediaVenueAlias InputMediaVenue
+
+func (m InputMediaVenue) MarshalInputMedia() ([]byte, error) {
+	return json.Marshal(struct {
 		Type string `json:"type"`
-		*InputMediaVenue
+		inputMediaVenueAlias
 	}{
-		Type:            "venue",
-		InputMediaVenue: m,
+		Type:                 "venue",
+		inputMediaVenueAlias: inputMediaVenueAlias(m),
 	})
+}
+
+// MarshalJSON keeps the required "type" discriminator when the value is reached
+// through a plain json.Marshal, e.g. nested inside a rich message.
+func (m InputMediaVenue) MarshalJSON() ([]byte, error) {
+	return m.MarshalInputMedia()
 }
 
 func (InputMediaVenue) inputMediaTag() {}

--- a/models/input_rich_block.go
+++ b/models/input_rich_block.go
@@ -36,9 +36,64 @@ type InputRichBlock struct {
 	InputRichBlockThinking               *InputRichBlockThinking
 }
 
+// variantIsNil reports whether the variant pointer matching Type is unset. An
+// InputRichBlock is built by the caller, so a Type without its variant is a
+// plausible mistake that must not reach json.Marshal as a nil dereference.
+func (rb InputRichBlock) variantIsNil() bool {
+	switch rb.Type {
+	case RichBlockTypeParagraph:
+		return rb.InputRichBlockParagraph == nil
+	case RichBlockTypeSectionHeading:
+		return rb.InputRichBlockSectionHeading == nil
+	case RichBlockTypePreformatted:
+		return rb.InputRichBlockPreformatted == nil
+	case RichBlockTypeFooter:
+		return rb.InputRichBlockFooter == nil
+	case RichBlockTypeDivider:
+		return rb.InputRichBlockDivider == nil
+	case RichBlockTypeMathematicalExpression:
+		return rb.InputRichBlockMathematicalExpression == nil
+	case RichBlockTypeAnchor:
+		return rb.InputRichBlockAnchor == nil
+	case RichBlockTypeList:
+		return rb.InputRichBlockList == nil
+	case RichBlockTypeBlockQuotation:
+		return rb.InputRichBlockBlockQuotation == nil
+	case RichBlockTypePullQuotation:
+		return rb.InputRichBlockPullQuotation == nil
+	case RichBlockTypeCollage:
+		return rb.InputRichBlockCollage == nil
+	case RichBlockTypeSlideshow:
+		return rb.InputRichBlockSlideshow == nil
+	case RichBlockTypeTable:
+		return rb.InputRichBlockTable == nil
+	case RichBlockTypeDetails:
+		return rb.InputRichBlockDetails == nil
+	case RichBlockTypeMap:
+		return rb.InputRichBlockMap == nil
+	case RichBlockTypeAnimation:
+		return rb.InputRichBlockAnimation == nil
+	case RichBlockTypeAudio:
+		return rb.InputRichBlockAudio == nil
+	case RichBlockTypePhoto:
+		return rb.InputRichBlockPhoto == nil
+	case RichBlockTypeVideo:
+		return rb.InputRichBlockVideo == nil
+	case RichBlockTypeVoiceNote:
+		return rb.InputRichBlockVoiceNote == nil
+	case RichBlockTypeThinking:
+		return rb.InputRichBlockThinking == nil
+	}
+	return true
+}
+
 // MarshalJSON implements json.Marshaler. The value receiver ensures the encoding
 // is applied even when an InputRichBlock is reached as a (non-pointer) struct field.
 func (rb InputRichBlock) MarshalJSON() ([]byte, error) {
+	if rb.variantIsNil() {
+		return nil, fmt.Errorf("nil variant for InputRichBlock type %q", rb.Type)
+	}
+
 	switch rb.Type {
 	case RichBlockTypeParagraph:
 		rb.InputRichBlockParagraph.Type = RichBlockTypeParagraph

--- a/models/input_rich_block.go
+++ b/models/input_rich_block.go
@@ -1,0 +1,363 @@
+package models
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// InputRichBlock https://core.telegram.org/bots/api#inputrichblock
+//
+// InputRichBlock is a tagged union describing a single block of an outgoing rich
+// message. Type holds the discriminator (reusing the RichBlockType values) and
+// the matching variant pointer is populated.
+type InputRichBlock struct {
+	Type RichBlockType
+
+	InputRichBlockParagraph              *InputRichBlockParagraph
+	InputRichBlockSectionHeading         *InputRichBlockSectionHeading
+	InputRichBlockPreformatted           *InputRichBlockPreformatted
+	InputRichBlockFooter                 *InputRichBlockFooter
+	InputRichBlockDivider                *InputRichBlockDivider
+	InputRichBlockMathematicalExpression *InputRichBlockMathematicalExpression
+	InputRichBlockAnchor                 *InputRichBlockAnchor
+	InputRichBlockList                   *InputRichBlockList
+	InputRichBlockBlockQuotation         *InputRichBlockBlockQuotation
+	InputRichBlockPullQuotation          *InputRichBlockPullQuotation
+	InputRichBlockCollage                *InputRichBlockCollage
+	InputRichBlockSlideshow              *InputRichBlockSlideshow
+	InputRichBlockTable                  *InputRichBlockTable
+	InputRichBlockDetails                *InputRichBlockDetails
+	InputRichBlockMap                    *InputRichBlockMap
+	InputRichBlockAnimation              *InputRichBlockAnimation
+	InputRichBlockAudio                  *InputRichBlockAudio
+	InputRichBlockPhoto                  *InputRichBlockPhoto
+	InputRichBlockVideo                  *InputRichBlockVideo
+	InputRichBlockVoiceNote              *InputRichBlockVoiceNote
+	InputRichBlockThinking               *InputRichBlockThinking
+}
+
+// MarshalJSON implements json.Marshaler. The value receiver ensures the encoding
+// is applied even when an InputRichBlock is reached as a (non-pointer) struct field.
+func (rb InputRichBlock) MarshalJSON() ([]byte, error) {
+	switch rb.Type {
+	case RichBlockTypeParagraph:
+		rb.InputRichBlockParagraph.Type = RichBlockTypeParagraph
+		return json.Marshal(rb.InputRichBlockParagraph)
+	case RichBlockTypeSectionHeading:
+		rb.InputRichBlockSectionHeading.Type = RichBlockTypeSectionHeading
+		return json.Marshal(rb.InputRichBlockSectionHeading)
+	case RichBlockTypePreformatted:
+		rb.InputRichBlockPreformatted.Type = RichBlockTypePreformatted
+		return json.Marshal(rb.InputRichBlockPreformatted)
+	case RichBlockTypeFooter:
+		rb.InputRichBlockFooter.Type = RichBlockTypeFooter
+		return json.Marshal(rb.InputRichBlockFooter)
+	case RichBlockTypeDivider:
+		rb.InputRichBlockDivider.Type = RichBlockTypeDivider
+		return json.Marshal(rb.InputRichBlockDivider)
+	case RichBlockTypeMathematicalExpression:
+		rb.InputRichBlockMathematicalExpression.Type = RichBlockTypeMathematicalExpression
+		return json.Marshal(rb.InputRichBlockMathematicalExpression)
+	case RichBlockTypeAnchor:
+		rb.InputRichBlockAnchor.Type = RichBlockTypeAnchor
+		return json.Marshal(rb.InputRichBlockAnchor)
+	case RichBlockTypeList:
+		rb.InputRichBlockList.Type = RichBlockTypeList
+		return json.Marshal(rb.InputRichBlockList)
+	case RichBlockTypeBlockQuotation:
+		rb.InputRichBlockBlockQuotation.Type = RichBlockTypeBlockQuotation
+		return json.Marshal(rb.InputRichBlockBlockQuotation)
+	case RichBlockTypePullQuotation:
+		rb.InputRichBlockPullQuotation.Type = RichBlockTypePullQuotation
+		return json.Marshal(rb.InputRichBlockPullQuotation)
+	case RichBlockTypeCollage:
+		rb.InputRichBlockCollage.Type = RichBlockTypeCollage
+		return json.Marshal(rb.InputRichBlockCollage)
+	case RichBlockTypeSlideshow:
+		rb.InputRichBlockSlideshow.Type = RichBlockTypeSlideshow
+		return json.Marshal(rb.InputRichBlockSlideshow)
+	case RichBlockTypeTable:
+		rb.InputRichBlockTable.Type = RichBlockTypeTable
+		return json.Marshal(rb.InputRichBlockTable)
+	case RichBlockTypeDetails:
+		rb.InputRichBlockDetails.Type = RichBlockTypeDetails
+		return json.Marshal(rb.InputRichBlockDetails)
+	case RichBlockTypeMap:
+		rb.InputRichBlockMap.Type = RichBlockTypeMap
+		return json.Marshal(rb.InputRichBlockMap)
+	case RichBlockTypeAnimation:
+		rb.InputRichBlockAnimation.Type = RichBlockTypeAnimation
+		return json.Marshal(rb.InputRichBlockAnimation)
+	case RichBlockTypeAudio:
+		rb.InputRichBlockAudio.Type = RichBlockTypeAudio
+		return json.Marshal(rb.InputRichBlockAudio)
+	case RichBlockTypePhoto:
+		rb.InputRichBlockPhoto.Type = RichBlockTypePhoto
+		return json.Marshal(rb.InputRichBlockPhoto)
+	case RichBlockTypeVideo:
+		rb.InputRichBlockVideo.Type = RichBlockTypeVideo
+		return json.Marshal(rb.InputRichBlockVideo)
+	case RichBlockTypeVoiceNote:
+		rb.InputRichBlockVoiceNote.Type = RichBlockTypeVoiceNote
+		return json.Marshal(rb.InputRichBlockVoiceNote)
+	case RichBlockTypeThinking:
+		rb.InputRichBlockThinking.Type = RichBlockTypeThinking
+		return json.Marshal(rb.InputRichBlockThinking)
+	}
+
+	return nil, fmt.Errorf("unsupported InputRichBlock type %q", rb.Type)
+}
+
+func (rb *InputRichBlock) UnmarshalJSON(data []byte) error {
+	v := struct {
+		Type RichBlockType `json:"type"`
+	}{}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	switch v.Type {
+	case RichBlockTypeParagraph:
+		rb.Type = RichBlockTypeParagraph
+		rb.InputRichBlockParagraph = &InputRichBlockParagraph{}
+		return json.Unmarshal(data, rb.InputRichBlockParagraph)
+	case RichBlockTypeSectionHeading:
+		rb.Type = RichBlockTypeSectionHeading
+		rb.InputRichBlockSectionHeading = &InputRichBlockSectionHeading{}
+		return json.Unmarshal(data, rb.InputRichBlockSectionHeading)
+	case RichBlockTypePreformatted:
+		rb.Type = RichBlockTypePreformatted
+		rb.InputRichBlockPreformatted = &InputRichBlockPreformatted{}
+		return json.Unmarshal(data, rb.InputRichBlockPreformatted)
+	case RichBlockTypeFooter:
+		rb.Type = RichBlockTypeFooter
+		rb.InputRichBlockFooter = &InputRichBlockFooter{}
+		return json.Unmarshal(data, rb.InputRichBlockFooter)
+	case RichBlockTypeDivider:
+		rb.Type = RichBlockTypeDivider
+		rb.InputRichBlockDivider = &InputRichBlockDivider{}
+		return json.Unmarshal(data, rb.InputRichBlockDivider)
+	case RichBlockTypeMathematicalExpression:
+		rb.Type = RichBlockTypeMathematicalExpression
+		rb.InputRichBlockMathematicalExpression = &InputRichBlockMathematicalExpression{}
+		return json.Unmarshal(data, rb.InputRichBlockMathematicalExpression)
+	case RichBlockTypeAnchor:
+		rb.Type = RichBlockTypeAnchor
+		rb.InputRichBlockAnchor = &InputRichBlockAnchor{}
+		return json.Unmarshal(data, rb.InputRichBlockAnchor)
+	case RichBlockTypeList:
+		rb.Type = RichBlockTypeList
+		rb.InputRichBlockList = &InputRichBlockList{}
+		return json.Unmarshal(data, rb.InputRichBlockList)
+	case RichBlockTypeBlockQuotation:
+		rb.Type = RichBlockTypeBlockQuotation
+		rb.InputRichBlockBlockQuotation = &InputRichBlockBlockQuotation{}
+		return json.Unmarshal(data, rb.InputRichBlockBlockQuotation)
+	case RichBlockTypePullQuotation:
+		rb.Type = RichBlockTypePullQuotation
+		rb.InputRichBlockPullQuotation = &InputRichBlockPullQuotation{}
+		return json.Unmarshal(data, rb.InputRichBlockPullQuotation)
+	case RichBlockTypeCollage:
+		rb.Type = RichBlockTypeCollage
+		rb.InputRichBlockCollage = &InputRichBlockCollage{}
+		return json.Unmarshal(data, rb.InputRichBlockCollage)
+	case RichBlockTypeSlideshow:
+		rb.Type = RichBlockTypeSlideshow
+		rb.InputRichBlockSlideshow = &InputRichBlockSlideshow{}
+		return json.Unmarshal(data, rb.InputRichBlockSlideshow)
+	case RichBlockTypeTable:
+		rb.Type = RichBlockTypeTable
+		rb.InputRichBlockTable = &InputRichBlockTable{}
+		return json.Unmarshal(data, rb.InputRichBlockTable)
+	case RichBlockTypeDetails:
+		rb.Type = RichBlockTypeDetails
+		rb.InputRichBlockDetails = &InputRichBlockDetails{}
+		return json.Unmarshal(data, rb.InputRichBlockDetails)
+	case RichBlockTypeMap:
+		rb.Type = RichBlockTypeMap
+		rb.InputRichBlockMap = &InputRichBlockMap{}
+		return json.Unmarshal(data, rb.InputRichBlockMap)
+	case RichBlockTypeAnimation:
+		rb.Type = RichBlockTypeAnimation
+		rb.InputRichBlockAnimation = &InputRichBlockAnimation{}
+		return json.Unmarshal(data, rb.InputRichBlockAnimation)
+	case RichBlockTypeAudio:
+		rb.Type = RichBlockTypeAudio
+		rb.InputRichBlockAudio = &InputRichBlockAudio{}
+		return json.Unmarshal(data, rb.InputRichBlockAudio)
+	case RichBlockTypePhoto:
+		rb.Type = RichBlockTypePhoto
+		rb.InputRichBlockPhoto = &InputRichBlockPhoto{}
+		return json.Unmarshal(data, rb.InputRichBlockPhoto)
+	case RichBlockTypeVideo:
+		rb.Type = RichBlockTypeVideo
+		rb.InputRichBlockVideo = &InputRichBlockVideo{}
+		return json.Unmarshal(data, rb.InputRichBlockVideo)
+	case RichBlockTypeVoiceNote:
+		rb.Type = RichBlockTypeVoiceNote
+		rb.InputRichBlockVoiceNote = &InputRichBlockVoiceNote{}
+		return json.Unmarshal(data, rb.InputRichBlockVoiceNote)
+	case RichBlockTypeThinking:
+		rb.Type = RichBlockTypeThinking
+		rb.InputRichBlockThinking = &InputRichBlockThinking{}
+		return json.Unmarshal(data, rb.InputRichBlockThinking)
+	}
+
+	return fmt.Errorf("unsupported InputRichBlock type %q", v.Type)
+}
+
+// InputRichBlockListItem https://core.telegram.org/bots/api#inputrichblocklistitem
+//
+// An item in a list to be sent.
+type InputRichBlockListItem struct {
+	Blocks      []InputRichBlock `json:"blocks"`
+	HasCheckbox bool             `json:"has_checkbox,omitempty"`
+	IsChecked   bool             `json:"is_checked,omitempty"`
+	Value       int              `json:"value,omitempty"`
+	Type        string           `json:"type,omitempty"`
+}
+
+// InputRichBlockParagraph https://core.telegram.org/bots/api#inputrichblockparagraph
+type InputRichBlockParagraph struct {
+	Type RichBlockType `json:"type"` // always "paragraph"
+	Text RichText      `json:"text"`
+}
+
+// InputRichBlockSectionHeading https://core.telegram.org/bots/api#inputrichblocksectionheading
+type InputRichBlockSectionHeading struct {
+	Type RichBlockType `json:"type"` // always "heading"
+	Text RichText      `json:"text"`
+	Size int           `json:"size"`
+}
+
+// InputRichBlockPreformatted https://core.telegram.org/bots/api#inputrichblockpreformatted
+type InputRichBlockPreformatted struct {
+	Type     RichBlockType `json:"type"` // always "pre"
+	Text     RichText      `json:"text"`
+	Language string        `json:"language,omitempty"`
+}
+
+// InputRichBlockFooter https://core.telegram.org/bots/api#inputrichblockfooter
+type InputRichBlockFooter struct {
+	Type RichBlockType `json:"type"` // always "footer"
+	Text RichText      `json:"text"`
+}
+
+// InputRichBlockDivider https://core.telegram.org/bots/api#inputrichblockdivider
+type InputRichBlockDivider struct {
+	Type RichBlockType `json:"type"` // always "divider"
+}
+
+// InputRichBlockMathematicalExpression https://core.telegram.org/bots/api#inputrichblockmathematicalexpression
+type InputRichBlockMathematicalExpression struct {
+	Type       RichBlockType `json:"type"` // always "mathematical_expression"
+	Expression string        `json:"expression"`
+}
+
+// InputRichBlockAnchor https://core.telegram.org/bots/api#inputrichblockanchor
+type InputRichBlockAnchor struct {
+	Type RichBlockType `json:"type"` // always "anchor"
+	Name string        `json:"name"`
+}
+
+// InputRichBlockList https://core.telegram.org/bots/api#inputrichblocklist
+type InputRichBlockList struct {
+	Type  RichBlockType            `json:"type"` // always "list"
+	Items []InputRichBlockListItem `json:"items"`
+}
+
+// InputRichBlockBlockQuotation https://core.telegram.org/bots/api#inputrichblockblockquotation
+type InputRichBlockBlockQuotation struct {
+	Type   RichBlockType    `json:"type"` // always "blockquote"
+	Blocks []InputRichBlock `json:"blocks"`
+	Credit *RichText        `json:"credit,omitempty"`
+}
+
+// InputRichBlockPullQuotation https://core.telegram.org/bots/api#inputrichblockpullquotation
+type InputRichBlockPullQuotation struct {
+	Type   RichBlockType `json:"type"` // always "pullquote"
+	Text   RichText      `json:"text"`
+	Credit *RichText     `json:"credit,omitempty"`
+}
+
+// InputRichBlockCollage https://core.telegram.org/bots/api#inputrichblockcollage
+type InputRichBlockCollage struct {
+	Type    RichBlockType     `json:"type"` // always "collage"
+	Blocks  []InputRichBlock  `json:"blocks"`
+	Caption *RichBlockCaption `json:"caption,omitempty"`
+}
+
+// InputRichBlockSlideshow https://core.telegram.org/bots/api#inputrichblockslideshow
+type InputRichBlockSlideshow struct {
+	Type    RichBlockType     `json:"type"` // always "slideshow"
+	Blocks  []InputRichBlock  `json:"blocks"`
+	Caption *RichBlockCaption `json:"caption,omitempty"`
+}
+
+// InputRichBlockTable https://core.telegram.org/bots/api#inputrichblocktable
+type InputRichBlockTable struct {
+	Type       RichBlockType          `json:"type"` // always "table"
+	Cells      [][]RichBlockTableCell `json:"cells"`
+	IsBordered bool                   `json:"is_bordered,omitempty"`
+	IsStriped  bool                   `json:"is_striped,omitempty"`
+	Caption    *RichText              `json:"caption,omitempty"`
+}
+
+// InputRichBlockDetails https://core.telegram.org/bots/api#inputrichblockdetails
+type InputRichBlockDetails struct {
+	Type    RichBlockType    `json:"type"` // always "details"
+	Summary RichText         `json:"summary"`
+	Blocks  []InputRichBlock `json:"blocks"`
+	IsOpen  bool             `json:"is_open,omitempty"`
+}
+
+// InputRichBlockMap https://core.telegram.org/bots/api#inputrichblockmap
+type InputRichBlockMap struct {
+	Type     RichBlockType     `json:"type"` // always "map"
+	Location Location          `json:"location"`
+	Zoom     int               `json:"zoom"`
+	Width    int               `json:"width"`
+	Height   int               `json:"height"`
+	Caption  *RichBlockCaption `json:"caption,omitempty"`
+}
+
+// InputRichBlockAnimation https://core.telegram.org/bots/api#inputrichblockanimation
+type InputRichBlockAnimation struct {
+	Type      RichBlockType       `json:"type"` // always "animation"
+	Animation InputMediaAnimation `json:"animation"`
+	Caption   *RichBlockCaption   `json:"caption,omitempty"`
+}
+
+// InputRichBlockAudio https://core.telegram.org/bots/api#inputrichblockaudio
+type InputRichBlockAudio struct {
+	Type    RichBlockType     `json:"type"` // always "audio"
+	Audio   InputMediaAudio   `json:"audio"`
+	Caption *RichBlockCaption `json:"caption,omitempty"`
+}
+
+// InputRichBlockPhoto https://core.telegram.org/bots/api#inputrichblockphoto
+type InputRichBlockPhoto struct {
+	Type    RichBlockType     `json:"type"` // always "photo"
+	Photo   InputMediaPhoto   `json:"photo"`
+	Caption *RichBlockCaption `json:"caption,omitempty"`
+}
+
+// InputRichBlockVideo https://core.telegram.org/bots/api#inputrichblockvideo
+type InputRichBlockVideo struct {
+	Type    RichBlockType     `json:"type"` // always "video"
+	Video   InputMediaVideo   `json:"video"`
+	Caption *RichBlockCaption `json:"caption,omitempty"`
+}
+
+// InputRichBlockVoiceNote https://core.telegram.org/bots/api#inputrichblockvoicenote
+type InputRichBlockVoiceNote struct {
+	Type      RichBlockType       `json:"type"` // always "voice_note"
+	VoiceNote InputMediaVoiceNote `json:"voice_note"`
+	Caption   *RichBlockCaption   `json:"caption,omitempty"`
+}
+
+// InputRichBlockThinking https://core.telegram.org/bots/api#inputrichblockthinking
+type InputRichBlockThinking struct {
+	Type RichBlockType `json:"type"` // always "thinking"
+	Text RichText      `json:"text"`
+}

--- a/models/input_rich_block_test.go
+++ b/models/input_rich_block_test.go
@@ -1,0 +1,87 @@
+package models
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestInputRichBlock_Marshal verifies each block variant marshals with the
+// correct "type" discriminator injected from the union tag.
+func TestInputRichBlock_Marshal(t *testing.T) {
+	cases := []struct {
+		name     string
+		block    InputRichBlock
+		wantType string
+	}{
+		{"paragraph", InputRichBlock{Type: RichBlockTypeParagraph, InputRichBlockParagraph: &InputRichBlockParagraph{Text: RichText{PlainText: "hi"}}}, "paragraph"},
+		{"heading", InputRichBlock{Type: RichBlockTypeSectionHeading, InputRichBlockSectionHeading: &InputRichBlockSectionHeading{Text: RichText{PlainText: "h"}, Size: 2}}, "heading"},
+		{"divider", InputRichBlock{Type: RichBlockTypeDivider, InputRichBlockDivider: &InputRichBlockDivider{}}, "divider"},
+		{"math", InputRichBlock{Type: RichBlockTypeMathematicalExpression, InputRichBlockMathematicalExpression: &InputRichBlockMathematicalExpression{Expression: "x^2"}}, "mathematical_expression"},
+		{"thinking", InputRichBlock{Type: RichBlockTypeThinking, InputRichBlockThinking: &InputRichBlockThinking{Text: RichText{PlainText: "reasoning"}}}, "thinking"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			out, err := json.Marshal(c.block)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			if !strings.Contains(string(out), `"type":"`+c.wantType+`"`) {
+				t.Fatalf("missing type %q in %s", c.wantType, out)
+			}
+		})
+	}
+}
+
+// TestInputRichBlockList_Nested verifies list items carry nested blocks.
+func TestInputRichBlockList_Nested(t *testing.T) {
+	block := InputRichBlock{
+		Type: RichBlockTypeList,
+		InputRichBlockList: &InputRichBlockList{
+			Items: []InputRichBlockListItem{
+				{Blocks: []InputRichBlock{{Type: RichBlockTypeParagraph, InputRichBlockParagraph: &InputRichBlockParagraph{Text: RichText{PlainText: "item"}}}}, HasCheckbox: true, IsChecked: true},
+			},
+		},
+	}
+	out, err := json.Marshal(block)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	s := string(out)
+	if !strings.Contains(s, `"type":"list"`) || !strings.Contains(s, `"has_checkbox":true`) {
+		t.Fatalf("unexpected list encoding: %s", s)
+	}
+}
+
+// TestInputRichMessage_BlocksAndMedia verifies the 10.2 fields on InputRichMessage.
+func TestInputRichMessage_BlocksAndMedia(t *testing.T) {
+	in := InputRichMessage{
+		Markdown: "![img](tg://photo?id=abc)",
+		Media: []InputRichMessageMedia{
+			{ID: "abc", Media: &InputMediaPhoto{Media: "file_id_123"}},
+		},
+		Blocks: []InputRichBlock{
+			{Type: RichBlockTypeParagraph, InputRichBlockParagraph: &InputRichBlockParagraph{Text: RichText{PlainText: "p"}}},
+		},
+	}
+	out, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	s := string(out)
+	if !strings.Contains(s, `"media"`) || !strings.Contains(s, `"blocks"`) {
+		t.Fatalf("expected media and blocks in %s", s)
+	}
+}
+
+// TestInputMediaVoiceNote verifies the new voice note input media marshals with type.
+func TestInputMediaVoiceNote(t *testing.T) {
+	m := InputMediaVoiceNote{Media: "attach://voice", Duration: 5}
+	out, err := m.MarshalInputMedia()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(out), `"type":"voice_note"`) {
+		t.Fatalf("expected voice_note type: %s", out)
+	}
+}

--- a/models/input_rich_block_test.go
+++ b/models/input_rich_block_test.go
@@ -85,3 +85,72 @@ func TestInputMediaVoiceNote(t *testing.T) {
 		t.Fatalf("expected voice_note type: %s", out)
 	}
 }
+
+// TestInputMedia_NestedTypeDiscriminator verifies InputMedia values keep their
+// required "type" field when reached through a plain json.Marshal, which is how
+// they are encoded once nested inside a rich message.
+func TestInputMedia_NestedTypeDiscriminator(t *testing.T) {
+	cases := []struct {
+		name  string
+		media any
+		want  string
+	}{
+		{"photo", InputMediaPhoto{Media: "id"}, `"type":"photo"`},
+		{"video", InputMediaVideo{Media: "id"}, `"type":"video"`},
+		{"animation", InputMediaAnimation{Media: "id"}, `"type":"animation"`},
+		{"audio", InputMediaAudio{Media: "id"}, `"type":"audio"`},
+		{"voice_note", InputMediaVoiceNote{Media: "id"}, `"type":"voice_note"`},
+		{"document", InputMediaDocument{Media: "id"}, `"type":"document"`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			out, err := json.Marshal(c.media)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			if !strings.Contains(string(out), c.want) {
+				t.Fatalf("expected %s in %s", c.want, out)
+			}
+		})
+	}
+}
+
+// TestInputRichMessage_NestedMediaType verifies the nested InputMedia inside a
+// rich message carries its type through the json.Marshal path used when sending.
+func TestInputRichMessage_NestedMediaType(t *testing.T) {
+	in := InputRichMessage{
+		Markdown: "![img](tg://photo?id=abc)",
+		Media:    []InputRichMessageMedia{{ID: "abc", Media: &InputMediaPhoto{Media: "file_id_123"}}},
+		Blocks: []InputRichBlock{
+			{Type: RichBlockTypePhoto, InputRichBlockPhoto: &InputRichBlockPhoto{Photo: InputMediaPhoto{Media: "p"}}},
+			{Type: RichBlockTypeAnimation, InputRichBlockAnimation: &InputRichBlockAnimation{Animation: InputMediaAnimation{Media: "a"}}},
+			{Type: RichBlockTypeVoiceNote, InputRichBlockVoiceNote: &InputRichBlockVoiceNote{VoiceNote: InputMediaVoiceNote{Media: "v"}}},
+		},
+	}
+	out, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	s := string(out)
+	for _, want := range []string{
+		`"media":{"type":"photo"`,
+		`"photo":{"type":"photo"`,
+		`"animation":{"type":"animation"`,
+		`"voice_note":{"type":"voice_note"`,
+	} {
+		if !strings.Contains(s, want) {
+			t.Fatalf("expected %s in %s", want, s)
+		}
+	}
+}
+
+// TestInputRichBlock_NilVariant verifies a Type set without its matching variant
+// pointer returns an error instead of panicking.
+func TestInputRichBlock_NilVariant(t *testing.T) {
+	if _, err := json.Marshal(InputRichBlock{Type: RichBlockTypeParagraph}); err == nil {
+		t.Fatal("expected error for nil variant pointer")
+	}
+	if _, err := json.Marshal(InputRichBlock{}); err == nil {
+		t.Fatal("expected error for empty InputRichBlock")
+	}
+}

--- a/models/message.go
+++ b/models/message.go
@@ -88,6 +88,8 @@ type Message struct {
 	SenderBoostCount              int                            `json:"sender_boost_count,omitempty"`
 	SenderBusinessBot             *User                          `json:"sender_business_bot,omitempty"`
 	SenderTag                     string                         `json:"sender_tag,omitempty"`
+	ReceiverUser                  *User                          `json:"receiver_user,omitempty"`
+	EphemeralMessageID            int                            `json:"ephemeral_message_id,omitempty"`
 	Date                          int                            `json:"date"`
 	BusinessConnectionID          string                         `json:"business_connection_id,omitempty"`
 	Chat                          Chat                           `json:"chat"`
@@ -176,6 +178,8 @@ type Message struct {
 	PaidMessagePriceChanged       *PaidMessagePriceChanged       `json:"paid_message_price_changed,omitempty"`
 	ChatOwnerLeft                 *ChatOwnerLeft                 `json:"chat_owner_left,omitempty"`
 	ChatOwnerChanged              *ChatOwnerChanged              `json:"chat_owner_changed,omitempty"`
+	CommunityChatAdded            *CommunityChatAdded            `json:"community_chat_added,omitempty"`
+	CommunityChatRemoved          *CommunityChatRemoved          `json:"community_chat_removed,omitempty"`
 	SuggestedPostApproved         *SuggestedPostApproved         `json:"suggested_post_approved,omitempty"`
 	SuggestedPostApprovalFailed   *SuggestedPostApprovalFailed   `json:"suggested_post_approval_failed,omitempty"`
 	SuggestedPostDeclined         *SuggestedPostDeclined         `json:"suggested_post_declined,omitempty"`

--- a/models/reply.go
+++ b/models/reply.go
@@ -45,7 +45,8 @@ type ExternalReplyInfo struct {
 
 // ReplyParameters https://core.telegram.org/bots/api#replyparameters
 type ReplyParameters struct {
-	MessageID                int             `json:"message_id"`
+	MessageID                int             `json:"message_id,omitempty"`
+	EphemeralMessageID       int             `json:"ephemeral_message_id,omitempty"`
 	ChatID                   any             `json:"chat_id,omitempty"`
 	AllowSendingWithoutReply bool            `json:"allow_sending_without_reply,omitempty"`
 	Quote                    string          `json:"quote,omitempty"`

--- a/models/rich_message.go
+++ b/models/rich_message.go
@@ -13,10 +13,21 @@ type RichMessage struct {
 // Describes a rich formatted message to be sent. The thinking block is expressed
 // by the custom HTML tag <tg-thinking> within HTML.
 type InputRichMessage struct {
-	HTML                string `json:"html,omitempty"`
-	Markdown            string `json:"markdown,omitempty"`
-	IsRTL               bool   `json:"is_rtl,omitempty"`
-	SkipEntityDetection bool   `json:"skip_entity_detection,omitempty"`
+	Blocks              []InputRichBlock        `json:"blocks,omitempty"`
+	HTML                string                  `json:"html,omitempty"`
+	Markdown            string                  `json:"markdown,omitempty"`
+	Media               []InputRichMessageMedia `json:"media,omitempty"`
+	IsRTL               bool                    `json:"is_rtl,omitempty"`
+	SkipEntityDetection bool                    `json:"skip_entity_detection,omitempty"`
+}
+
+// InputRichMessageMedia https://core.telegram.org/bots/api#inputrichmessagemedia
+//
+// Media referenced from the markdown or html fields of an InputRichMessage via
+// tg://photo?id=, tg://video?id=, and tg://audio?id= links.
+type InputRichMessageMedia struct {
+	ID    string     `json:"id"`
+	Media InputMedia `json:"media"`
 }
 
 // InputRichMessageContent https://core.telegram.org/bots/api#inputrichmessagecontent

--- a/models/subscription.go
+++ b/models/subscription.go
@@ -1,0 +1,20 @@
+package models
+
+// BotSubscriptionState https://core.telegram.org/bots/api#botsubscriptionupdated
+type BotSubscriptionState string
+
+const (
+	BotSubscriptionStateCanceled BotSubscriptionState = "canceled"
+	BotSubscriptionStateActive   BotSubscriptionState = "active"
+	BotSubscriptionStateFailed   BotSubscriptionState = "failed"
+)
+
+// BotSubscriptionUpdated https://core.telegram.org/bots/api#botsubscriptionupdated
+//
+// Contains information about changes to a user payment subscription toward the
+// current bot.
+type BotSubscriptionUpdated struct {
+	User           User                 `json:"user"`
+	InvoicePayload string               `json:"invoice_payload"`
+	State          BotSubscriptionState `json:"state"`
+}

--- a/models/update.go
+++ b/models/update.go
@@ -28,6 +28,7 @@ type Update struct {
 	ChatJoinRequest         *ChatJoinRequest             `json:"chat_join_request,omitempty"`
 	ChatBoost               *ChatBoostUpdated            `json:"chat_boost,omitempty"`
 	RemovedChatBoost        *ChatBoostRemoved            `json:"removed_chat_boost,omitempty"`
+	Subscription            *BotSubscriptionUpdated      `json:"subscription,omitempty"`
 }
 
 // allowed_updates https://core.telegram.org/bots/api#update
@@ -57,4 +58,5 @@ const (
 	AllowedUpdateRemovedChatBoost        string = "removed_chat_boost"
 	AllowedUpdateManagedBot              string = "managed_bot"
 	AllowedUpdateGuestMessage            string = "guest_message"
+	AllowedUpdateSubscription            string = "subscription"
 )


### PR DESCRIPTION
Full support for Bot API 10.2.

Rich Messages: InputMediaVoiceNote, InputRichMessageMedia, InputRichBlock union (21 block types) + InputRichBlockListItem; blocks and media fields on InputRichMessage.

Ephemeral Messages: messages/commands visible only to one user + the bot:
- New methods EditEphemeralMessage{Text,Media,Caption,ReplyMarkup}, DeleteEphemeralMessage.
- ReceiverUserID + CallbackQueryID on the 13 send methods.
- BotCommand.IsEphemeral; Message.ReceiverUser / EphemeralMessageID; ReplyParameters.EphemeralMessageID (message_id now optional).

Communities: Community, CommunityChatAdded, CommunityChatRemoved; fields on Message and ChatFullInfo.

General: BotSubscriptionUpdated + Update.Subscription.

Notes: rich messages stay JSON-only (file_id/URL/tg://); attach:// upload in blocks out of scope. Mini App same-origin hardening is BotFather-side. Tests added (TDD), make check green.