### PR TITLE
fix: honour retry_after on 429 instead of the fixed backoff

### DIFF
--- a/get_updates.go
+++ b/get_updates.go
@@ -64,7 +64,14 @@ func (b *Bot) getUpdates(ctx context.Context, wg *sync.WaitGroup) {
 				return
 			}
 			b.error("error get updates, %w", errRequest)
-			timeoutAfterError = incErrTimeout(timeoutAfterError)
+
+			var tooManyRequestsErr *TooManyRequestsError
+			if errors.As(errRequest, &tooManyRequestsErr) && tooManyRequestsErr.RetryAfter > 0 {
+				timeoutAfterError = time.Duration(tooManyRequestsErr.RetryAfter) * time.Second
+			} else {
+				timeoutAfterError = incErrTimeout(timeoutAfterError)
+			}
+
 			continue
 		}
 


### PR DESCRIPTION
Came across this while building a bot - I was getting heaps of 429's and assumed my code was at fault. It's the `getUpdates` retry loop, it discards the `TooManyRequestsError.RetryAfter` and applies `incErrTimeout` instead.
The value is already parsed in `errors.go` but just wasnt used here.