### PR TITLE
refactor : inline-query handler type and register

### DIFF
--- a/examples/inline_mode/main.go
+++ b/examples/inline_mode/main.go
@@ -15,9 +15,7 @@ func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer cancel()
 
-	opts := []bot.Option{
-		bot.WithDefaultHandler(handler),
-	}
+	opts := []bot.Option{}
 
 	b, err := bot.New(os.Getenv("EXAMPLE_TELEGRAM_BOT_TOKEN"), opts...)
 	if nil != err {
@@ -25,15 +23,12 @@ func main() {
 		// you should handle this error properly in your code.
 		panic(err)
 	}
-
+	// register inline query handler
+	b.RegisterInlineQueryHandler(handler)
 	b.Start(ctx)
 }
 
 func handler(ctx context.Context, b *bot.Bot, update *models.Update) {
-	if update.InlineQuery == nil {
-		return
-	}
-
 	results := []models.InlineQueryResult{
 		&models.InlineQueryResultArticle{ID: "1", Title: "Foo 1", InputMessageContent: &models.InputTextMessageContent{MessageText: "foo 1"}},
 		&models.InlineQueryResultArticle{ID: "2", Title: "Foo 2", InputMessageContent: &models.InputTextMessageContent{MessageText: "foo 2"}},

--- a/handlers.go
+++ b/handlers.go
@@ -14,6 +14,7 @@ const (
 	HandlerTypeCallbackQueryData
 	HandlerTypeCallbackQueryGameShortName
 	HandlerTypePhotoCaption
+	HandlerTypeInlineQuery
 )
 
 type MatchType int
@@ -71,6 +72,12 @@ func (h handler) match(update *models.Update) bool {
 		}
 		data = update.Message.Caption
 		entities = update.Message.CaptionEntities
+	case HandlerTypeInlineQuery:
+		if update.InlineQuery == nil {
+			return false
+		}
+		return true
+
 	}
 
 	if h.matchType == MatchTypeExact {
@@ -135,6 +142,23 @@ func (b *Bot) RegisterHandlerRegexp(handlerType HandlerType, re *regexp.Regexp, 
 		handlerType: handlerType,
 		matchType:   matchTypeRegexp,
 		re:          re,
+		handler:     applyMiddlewares(f, m...),
+	}
+
+	b.handlers = append(b.handlers, h)
+
+	return id
+}
+
+func (b *Bot) RegisterInlineQueryHandler(f HandlerFunc, m ...Middleware) string {
+	b.handlersMx.Lock()
+	defer b.handlersMx.Unlock()
+
+	id := RandomString(16)
+
+	h := handler{
+		id:          id,
+		handlerType: HandlerTypeInlineQuery,
 		handler:     applyMiddlewares(f, m...),
 	}
 


### PR DESCRIPTION
## Description
This PR addresses issue #293 by refactoring the inline query handling mechanism to make it cleaner and more idiomatic. 

Instead of relying on the existing workaround in the examples directory, this change introduces a dedicated handler type specifically designed for inline query interactions.

## Changes Made
- Added `HandlerTypeInlineQuery` to the `HandlerType` enum/constants.
- Updated the `match` function logic with a new `case` to properly route `HandlerTypeInlineQuery`.
- Refactored the inline query example in `examples/` to demonstrate the new implementation.

## Related Issue
#293
