### PR TITLE
feat: support Bot API 10.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## v1.24.0 (2026-08-24)
+
+- Support Bot API 10.3 (August 24, 2026 update):
+  - Rich Messages: new `RichMessageButton`; `RichTextButton` (via the `RichText`
+    union); `RichBlockButtons`, `RichBlockExpandableBlockQuotation`,
+    `RichBlockDocument` and their `InputRichBlock*` counterparts (via the
+    `RichBlock` / `InputRichBlock` unions); `is_compact` on `RichBlockTable` and
+    `InputRichBlockTable`; `tg://document?id=` links for `InputRichMessageMedia`.
+  - Ephemeral Messages: new `EphemeralMessageParameters` (with
+    `replace_callback_query_message`), sent as `ephemeral_message_parameters` by
+    the 13 send methods and `sendRichMessage`; `rich_message` on
+    `editEphemeralMessageText` (and `text` made optional);
+    `show_caption_above_media` on `editEphemeralMessageCaption`; upload of new
+    files in `editEphemeralMessageMedia`; `can_send_welcome_messages` on
+    `ChatAdministratorRights`, `ChatMemberAdministrator` and `promoteChatMember`.
+  - Reply markup: new `DisabledButton` with the `disabled` field on
+    `InlineKeyboardButton`; `force_reply` on `InlineKeyboardMarkup` and
+    `ReplyKeyboardMarkup`.
+  - General: `can_stop` and `keep_on_stop` on `sendMessageDraft` and
+    `sendRichMessageDraft`; new `MessageGenerationStopped` with the
+    `stopped_message_generation` field on `Update` (and the matching
+    allowed-update constant); new `CommunityChatJoined` with
+    `community_chat_joined` on `Message`; `text`, `entities` and `is_private` on
+    `UniqueGiftInfo`.
+- Breaking: `ReceiverUserID` and `CallbackQueryID` are removed from the send
+  method params (`SendMessageParams`, `SendPhotoParams`, ...); Bot API 10.3
+  replaced them with `EphemeralMessageParameters`.
+
 ## v1.23.0 (2026-08-03)
 
 - Support Bot API 10.2 (July 14, 2026 update):

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 > [Telegram Group](https://t.me/gotelegrambotui)
 
-> Supports Bot API version: [10.2](https://core.telegram.org/bots/api#july-14-2026) from July 14, 2026
+> Supports Bot API version: [10.3](https://core.telegram.org/bots/api#august-24-2026) from August 24, 2026
 
 It's a Go zero-dependencies telegram bot framework
 

--- a/methods_params.go
+++ b/methods_params.go
@@ -20,23 +20,22 @@ type DeleteWebhookParams struct {
 
 // SendMessageParams https://core.telegram.org/bots/api#sendmessage
 type SendMessageParams struct {
-	BusinessConnectionID    string                          `json:"business_connection_id,omitempty"`
-	ChatID                  any                             `json:"chat_id"`
-	MessageThreadID         int                             `json:"message_thread_id,omitempty"`
-	DirectMessagesTopicID   int                             `json:"direct_messages_topic_id,omitempty"`
-	ReceiverUserID          int64                           `json:"receiver_user_id,omitempty"`
-	CallbackQueryID         string                          `json:"callback_query_id,omitempty"`
-	Text                    string                          `json:"text"`
-	ParseMode               models.ParseMode                `json:"parse_mode,omitempty"`
-	Entities                []models.MessageEntity          `json:"entities,omitempty"`
-	LinkPreviewOptions      *models.LinkPreviewOptions      `json:"link_preview_options,omitempty"`
-	DisableNotification     bool                            `json:"disable_notification,omitempty"`
-	ProtectContent          bool                            `json:"protect_content,omitempty"`
-	AllowPaidBroadcast      bool                            `json:"allow_paid_broadcast,omitempty"`
-	MessageEffectID         string                          `json:"message_effect_id,omitempty"`
-	SuggestedPostParameters *models.SuggestedPostParameters `json:"suggested_post_parameters,omitempty"`
-	ReplyParameters         *models.ReplyParameters         `json:"reply_parameters,omitempty"`
-	ReplyMarkup             models.ReplyMarkup              `json:"reply_markup,omitempty"`
+	BusinessConnectionID       string                             `json:"business_connection_id,omitempty"`
+	ChatID                     any                                `json:"chat_id"`
+	MessageThreadID            int                                `json:"message_thread_id,omitempty"`
+	DirectMessagesTopicID      int                                `json:"direct_messages_topic_id,omitempty"`
+	EphemeralMessageParameters *models.EphemeralMessageParameters `json:"ephemeral_message_parameters,omitempty"`
+	Text                       string                             `json:"text"`
+	ParseMode                  models.ParseMode                   `json:"parse_mode,omitempty"`
+	Entities                   []models.MessageEntity             `json:"entities,omitempty"`
+	LinkPreviewOptions         *models.LinkPreviewOptions         `json:"link_preview_options,omitempty"`
+	DisableNotification        bool                               `json:"disable_notification,omitempty"`
+	ProtectContent             bool                               `json:"protect_content,omitempty"`
+	AllowPaidBroadcast         bool                               `json:"allow_paid_broadcast,omitempty"`
+	MessageEffectID            string                             `json:"message_effect_id,omitempty"`
+	SuggestedPostParameters    *models.SuggestedPostParameters    `json:"suggested_post_parameters,omitempty"`
+	ReplyParameters            *models.ReplyParameters            `json:"reply_parameters,omitempty"`
+	ReplyMarkup                models.ReplyMarkup                 `json:"reply_markup,omitempty"`
 }
 
 // ForwardMessageParams https://core.telegram.org/bots/api#forwardmessage
@@ -99,173 +98,166 @@ type CopyMessagesParams struct {
 
 // SendPhotoParams https://core.telegram.org/bots/api#sendphoto
 type SendPhotoParams struct {
-	BusinessConnectionID    string                          `json:"business_connection_id,omitempty"`
-	ChatID                  any                             `json:"chat_id"`
-	MessageThreadID         int                             `json:"message_thread_id,omitempty"`
-	DirectMessagesTopicID   int                             `json:"direct_messages_topic_id,omitempty"`
-	ReceiverUserID          int64                           `json:"receiver_user_id,omitempty"`
-	CallbackQueryID         string                          `json:"callback_query_id,omitempty"`
-	Photo                   models.InputFile                `json:"photo"`
-	Caption                 string                          `json:"caption,omitempty"`
-	ParseMode               models.ParseMode                `json:"parse_mode,omitempty"`
-	CaptionEntities         []models.MessageEntity          `json:"caption_entities,omitempty"`
-	ShowCaptionAboveMedia   bool                            `json:"show_caption_above_media,omitempty"`
-	HasSpoiler              bool                            `json:"has_spoiler,omitempty"`
-	DisableNotification     bool                            `json:"disable_notification,omitempty"`
-	ProtectContent          bool                            `json:"protect_content,omitempty"`
-	AllowPaidBroadcast      bool                            `json:"allow_paid_broadcast,omitempty"`
-	MessageEffectID         string                          `json:"message_effect_id,omitempty"`
-	SuggestedPostParameters *models.SuggestedPostParameters `json:"suggested_post_parameters,omitempty"`
-	ReplyParameters         *models.ReplyParameters         `json:"reply_parameters,omitempty"`
-	ReplyMarkup             models.ReplyMarkup              `json:"reply_markup,omitempty"`
+	BusinessConnectionID       string                             `json:"business_connection_id,omitempty"`
+	ChatID                     any                                `json:"chat_id"`
+	MessageThreadID            int                                `json:"message_thread_id,omitempty"`
+	DirectMessagesTopicID      int                                `json:"direct_messages_topic_id,omitempty"`
+	EphemeralMessageParameters *models.EphemeralMessageParameters `json:"ephemeral_message_parameters,omitempty"`
+	Photo                      models.InputFile                   `json:"photo"`
+	Caption                    string                             `json:"caption,omitempty"`
+	ParseMode                  models.ParseMode                   `json:"parse_mode,omitempty"`
+	CaptionEntities            []models.MessageEntity             `json:"caption_entities,omitempty"`
+	ShowCaptionAboveMedia      bool                               `json:"show_caption_above_media,omitempty"`
+	HasSpoiler                 bool                               `json:"has_spoiler,omitempty"`
+	DisableNotification        bool                               `json:"disable_notification,omitempty"`
+	ProtectContent             bool                               `json:"protect_content,omitempty"`
+	AllowPaidBroadcast         bool                               `json:"allow_paid_broadcast,omitempty"`
+	MessageEffectID            string                             `json:"message_effect_id,omitempty"`
+	SuggestedPostParameters    *models.SuggestedPostParameters    `json:"suggested_post_parameters,omitempty"`
+	ReplyParameters            *models.ReplyParameters            `json:"reply_parameters,omitempty"`
+	ReplyMarkup                models.ReplyMarkup                 `json:"reply_markup,omitempty"`
 }
 
 // SendAudioParams https://core.telegram.org/bots/api#sendaudio
 type SendAudioParams struct {
-	BusinessConnectionID    string                          `json:"business_connection_id,omitempty"`
-	ChatID                  any                             `json:"chat_id"`
-	MessageThreadID         int                             `json:"message_thread_id,omitempty"`
-	DirectMessagesTopicID   int                             `json:"direct_messages_topic_id,omitempty"`
-	ReceiverUserID          int64                           `json:"receiver_user_id,omitempty"`
-	CallbackQueryID         string                          `json:"callback_query_id,omitempty"`
-	Audio                   models.InputFile                `json:"audio"`
-	Caption                 string                          `json:"caption,omitempty"`
-	ParseMode               models.ParseMode                `json:"parse_mode,omitempty"`
-	CaptionEntities         []models.MessageEntity          `json:"caption_entities,omitempty"`
-	Duration                int                             `json:"duration,omitempty"`
-	Performer               string                          `json:"performer,omitempty"`
-	Title                   string                          `json:"title,omitempty"`
-	Thumbnail               models.InputFile                `json:"thumbnail,omitempty"`
-	DisableNotification     bool                            `json:"disable_notification,omitempty"`
-	ProtectContent          bool                            `json:"protect_content,omitempty"`
-	AllowPaidBroadcast      bool                            `json:"allow_paid_broadcast,omitempty"`
-	MessageEffectID         string                          `json:"message_effect_id,omitempty"`
-	SuggestedPostParameters *models.SuggestedPostParameters `json:"suggested_post_parameters,omitempty"`
-	ReplyParameters         *models.ReplyParameters         `json:"reply_parameters,omitempty"`
-	ReplyMarkup             models.ReplyMarkup              `json:"reply_markup,omitempty"`
+	BusinessConnectionID       string                             `json:"business_connection_id,omitempty"`
+	ChatID                     any                                `json:"chat_id"`
+	MessageThreadID            int                                `json:"message_thread_id,omitempty"`
+	DirectMessagesTopicID      int                                `json:"direct_messages_topic_id,omitempty"`
+	EphemeralMessageParameters *models.EphemeralMessageParameters `json:"ephemeral_message_parameters,omitempty"`
+	Audio                      models.InputFile                   `json:"audio"`
+	Caption                    string                             `json:"caption,omitempty"`
+	ParseMode                  models.ParseMode                   `json:"parse_mode,omitempty"`
+	CaptionEntities            []models.MessageEntity             `json:"caption_entities,omitempty"`
+	Duration                   int                                `json:"duration,omitempty"`
+	Performer                  string                             `json:"performer,omitempty"`
+	Title                      string                             `json:"title,omitempty"`
+	Thumbnail                  models.InputFile                   `json:"thumbnail,omitempty"`
+	DisableNotification        bool                               `json:"disable_notification,omitempty"`
+	ProtectContent             bool                               `json:"protect_content,omitempty"`
+	AllowPaidBroadcast         bool                               `json:"allow_paid_broadcast,omitempty"`
+	MessageEffectID            string                             `json:"message_effect_id,omitempty"`
+	SuggestedPostParameters    *models.SuggestedPostParameters    `json:"suggested_post_parameters,omitempty"`
+	ReplyParameters            *models.ReplyParameters            `json:"reply_parameters,omitempty"`
+	ReplyMarkup                models.ReplyMarkup                 `json:"reply_markup,omitempty"`
 }
 
 // SendDocumentParams https://core.telegram.org/bots/api#senddocument
 type SendDocumentParams struct {
-	BusinessConnectionID        string                          `json:"business_connection_id,omitempty"`
-	ChatID                      any                             `json:"chat_id"`
-	MessageThreadID             int                             `json:"message_thread_id,omitempty"`
-	DirectMessagesTopicID       int                             `json:"direct_messages_topic_id,omitempty"`
-	ReceiverUserID              int64                           `json:"receiver_user_id,omitempty"`
-	CallbackQueryID             string                          `json:"callback_query_id,omitempty"`
-	Document                    models.InputFile                `json:"document"`
-	Thumbnail                   models.InputFile                `json:"thumbnail,omitempty"`
-	Caption                     string                          `json:"caption,omitempty"`
-	ParseMode                   models.ParseMode                `json:"parse_mode,omitempty"`
-	CaptionEntities             []models.MessageEntity          `json:"caption_entities,omitempty"`
-	DisableContentTypeDetection bool                            `json:"disable_content_type_detection,omitempty"`
-	DisableNotification         bool                            `json:"disable_notification,omitempty"`
-	ProtectContent              bool                            `json:"protect_content,omitempty"`
-	AllowPaidBroadcast          bool                            `json:"allow_paid_broadcast,omitempty"`
-	MessageEffectID             string                          `json:"message_effect_id,omitempty"`
-	SuggestedPostParameters     *models.SuggestedPostParameters `json:"suggested_post_parameters,omitempty"`
-	ReplyParameters             *models.ReplyParameters         `json:"reply_parameters,omitempty"`
-	ReplyMarkup                 models.ReplyMarkup              `json:"reply_markup,omitempty"`
+	BusinessConnectionID        string                             `json:"business_connection_id,omitempty"`
+	ChatID                      any                                `json:"chat_id"`
+	MessageThreadID             int                                `json:"message_thread_id,omitempty"`
+	DirectMessagesTopicID       int                                `json:"direct_messages_topic_id,omitempty"`
+	EphemeralMessageParameters  *models.EphemeralMessageParameters `json:"ephemeral_message_parameters,omitempty"`
+	Document                    models.InputFile                   `json:"document"`
+	Thumbnail                   models.InputFile                   `json:"thumbnail,omitempty"`
+	Caption                     string                             `json:"caption,omitempty"`
+	ParseMode                   models.ParseMode                   `json:"parse_mode,omitempty"`
+	CaptionEntities             []models.MessageEntity             `json:"caption_entities,omitempty"`
+	DisableContentTypeDetection bool                               `json:"disable_content_type_detection,omitempty"`
+	DisableNotification         bool                               `json:"disable_notification,omitempty"`
+	ProtectContent              bool                               `json:"protect_content,omitempty"`
+	AllowPaidBroadcast          bool                               `json:"allow_paid_broadcast,omitempty"`
+	MessageEffectID             string                             `json:"message_effect_id,omitempty"`
+	SuggestedPostParameters     *models.SuggestedPostParameters    `json:"suggested_post_parameters,omitempty"`
+	ReplyParameters             *models.ReplyParameters            `json:"reply_parameters,omitempty"`
+	ReplyMarkup                 models.ReplyMarkup                 `json:"reply_markup,omitempty"`
 }
 
 // SendVideoParams https://core.telegram.org/bots/api#sendvideo
 type SendVideoParams struct {
-	BusinessConnectionID    string                          `json:"business_connection_id,omitempty"`
-	ChatID                  any                             `json:"chat_id"`
-	MessageThreadID         int                             `json:"message_thread_id,omitempty"`
-	DirectMessagesTopicID   int                             `json:"direct_messages_topic_id,omitempty"`
-	ReceiverUserID          int64                           `json:"receiver_user_id,omitempty"`
-	CallbackQueryID         string                          `json:"callback_query_id,omitempty"`
-	Video                   models.InputFile                `json:"video"`
-	Duration                int                             `json:"duration,omitempty"`
-	Width                   int                             `json:"width,omitempty"`
-	Height                  int                             `json:"height,omitempty"`
-	Thumbnail               models.InputFile                `json:"thumbnail,omitempty"`
-	Cover                   models.InputFile                `json:"cover,omitempty"`
-	StartTimestamp          int                             `json:"start_timestamp,omitempty"`
-	Caption                 string                          `json:"caption,omitempty"`
-	ParseMode               models.ParseMode                `json:"parse_mode,omitempty"`
-	CaptionEntities         []models.MessageEntity          `json:"caption_entities,omitempty"`
-	ShowCaptionAboveMedia   bool                            `json:"show_caption_above_media,omitempty"`
-	HasSpoiler              bool                            `json:"has_spoiler,omitempty"`
-	SupportsStreaming       bool                            `json:"supports_streaming,omitempty"`
-	DisableNotification     bool                            `json:"disable_notification,omitempty"`
-	ProtectContent          bool                            `json:"protect_content,omitempty"`
-	AllowPaidBroadcast      bool                            `json:"allow_paid_broadcast,omitempty"`
-	MessageEffectID         string                          `json:"message_effect_id,omitempty"`
-	SuggestedPostParameters *models.SuggestedPostParameters `json:"suggested_post_parameters,omitempty"`
-	ReplyParameters         *models.ReplyParameters         `json:"reply_parameters,omitempty"`
-	ReplyMarkup             models.ReplyMarkup              `json:"reply_markup,omitempty"`
+	BusinessConnectionID       string                             `json:"business_connection_id,omitempty"`
+	ChatID                     any                                `json:"chat_id"`
+	MessageThreadID            int                                `json:"message_thread_id,omitempty"`
+	DirectMessagesTopicID      int                                `json:"direct_messages_topic_id,omitempty"`
+	EphemeralMessageParameters *models.EphemeralMessageParameters `json:"ephemeral_message_parameters,omitempty"`
+	Video                      models.InputFile                   `json:"video"`
+	Duration                   int                                `json:"duration,omitempty"`
+	Width                      int                                `json:"width,omitempty"`
+	Height                     int                                `json:"height,omitempty"`
+	Thumbnail                  models.InputFile                   `json:"thumbnail,omitempty"`
+	Cover                      models.InputFile                   `json:"cover,omitempty"`
+	StartTimestamp             int                                `json:"start_timestamp,omitempty"`
+	Caption                    string                             `json:"caption,omitempty"`
+	ParseMode                  models.ParseMode                   `json:"parse_mode,omitempty"`
+	CaptionEntities            []models.MessageEntity             `json:"caption_entities,omitempty"`
+	ShowCaptionAboveMedia      bool                               `json:"show_caption_above_media,omitempty"`
+	HasSpoiler                 bool                               `json:"has_spoiler,omitempty"`
+	SupportsStreaming          bool                               `json:"supports_streaming,omitempty"`
+	DisableNotification        bool                               `json:"disable_notification,omitempty"`
+	ProtectContent             bool                               `json:"protect_content,omitempty"`
+	AllowPaidBroadcast         bool                               `json:"allow_paid_broadcast,omitempty"`
+	MessageEffectID            string                             `json:"message_effect_id,omitempty"`
+	SuggestedPostParameters    *models.SuggestedPostParameters    `json:"suggested_post_parameters,omitempty"`
+	ReplyParameters            *models.ReplyParameters            `json:"reply_parameters,omitempty"`
+	ReplyMarkup                models.ReplyMarkup                 `json:"reply_markup,omitempty"`
 }
 
 // SendAnimationParams https://core.telegram.org/bots/api#sendanimation
 type SendAnimationParams struct {
-	BusinessConnectionID    string                          `json:"business_connection_id,omitempty"`
-	ChatID                  any                             `json:"chat_id"`
-	MessageThreadID         int                             `json:"message_thread_id,omitempty"`
-	DirectMessagesTopicID   int                             `json:"direct_messages_topic_id,omitempty"`
-	ReceiverUserID          int64                           `json:"receiver_user_id,omitempty"`
-	CallbackQueryID         string                          `json:"callback_query_id,omitempty"`
-	Animation               models.InputFile                `json:"animation"`
-	Duration                int                             `json:"duration,omitempty"`
-	Width                   int                             `json:"width,omitempty"`
-	Height                  int                             `json:"height,omitempty"`
-	Thumbnail               models.InputFile                `json:"thumbnail,omitempty"`
-	Caption                 string                          `json:"caption,omitempty"`
-	ParseMode               models.ParseMode                `json:"parse_mode,omitempty"`
-	CaptionEntities         []models.MessageEntity          `json:"caption_entities,omitempty"`
-	ShowCaptionAboveMedia   bool                            `json:"show_caption_above_media,omitempty"`
-	HasSpoiler              bool                            `json:"has_spoiler,omitempty"`
-	DisableNotification     bool                            `json:"disable_notification,omitempty"`
-	ProtectContent          bool                            `json:"protect_content,omitempty"`
-	AllowPaidBroadcast      bool                            `json:"allow_paid_broadcast,omitempty"`
-	MessageEffectID         string                          `json:"message_effect_id,omitempty"`
-	SuggestedPostParameters *models.SuggestedPostParameters `json:"suggested_post_parameters,omitempty"`
-	ReplyParameters         *models.ReplyParameters         `json:"reply_parameters,omitempty"`
-	ReplyMarkup             models.ReplyMarkup              `json:"reply_markup,omitempty"`
+	BusinessConnectionID       string                             `json:"business_connection_id,omitempty"`
+	ChatID                     any                                `json:"chat_id"`
+	MessageThreadID            int                                `json:"message_thread_id,omitempty"`
+	DirectMessagesTopicID      int                                `json:"direct_messages_topic_id,omitempty"`
+	EphemeralMessageParameters *models.EphemeralMessageParameters `json:"ephemeral_message_parameters,omitempty"`
+	Animation                  models.InputFile                   `json:"animation"`
+	Duration                   int                                `json:"duration,omitempty"`
+	Width                      int                                `json:"width,omitempty"`
+	Height                     int                                `json:"height,omitempty"`
+	Thumbnail                  models.InputFile                   `json:"thumbnail,omitempty"`
+	Caption                    string                             `json:"caption,omitempty"`
+	ParseMode                  models.ParseMode                   `json:"parse_mode,omitempty"`
+	CaptionEntities            []models.MessageEntity             `json:"caption_entities,omitempty"`
+	ShowCaptionAboveMedia      bool                               `json:"show_caption_above_media,omitempty"`
+	HasSpoiler                 bool                               `json:"has_spoiler,omitempty"`
+	DisableNotification        bool                               `json:"disable_notification,omitempty"`
+	ProtectContent             bool                               `json:"protect_content,omitempty"`
+	AllowPaidBroadcast         bool                               `json:"allow_paid_broadcast,omitempty"`
+	MessageEffectID            string                             `json:"message_effect_id,omitempty"`
+	SuggestedPostParameters    *models.SuggestedPostParameters    `json:"suggested_post_parameters,omitempty"`
+	ReplyParameters            *models.ReplyParameters            `json:"reply_parameters,omitempty"`
+	ReplyMarkup                models.ReplyMarkup                 `json:"reply_markup,omitempty"`
 }
 
 // SendVoiceParams https://core.telegram.org/bots/api#sendvoice
 type SendVoiceParams struct {
-	BusinessConnectionID    string                          `json:"business_connection_id,omitempty"`
-	ChatID                  any                             `json:"chat_id"`
-	MessageThreadID         int                             `json:"message_thread_id,omitempty"`
-	DirectMessagesTopicID   int                             `json:"direct_messages_topic_id,omitempty"`
-	ReceiverUserID          int64                           `json:"receiver_user_id,omitempty"`
-	CallbackQueryID         string                          `json:"callback_query_id,omitempty"`
-	Voice                   models.InputFile                `json:"voice"`
-	Caption                 string                          `json:"caption,omitempty"`
-	ParseMode               models.ParseMode                `json:"parse_mode,omitempty"`
-	CaptionEntities         []models.MessageEntity          `json:"caption_entities,omitempty"`
-	Duration                int                             `json:"duration,omitempty"`
-	DisableNotification     bool                            `json:"disable_notification,omitempty"`
-	ProtectContent          bool                            `json:"protect_content,omitempty"`
-	AllowPaidBroadcast      bool                            `json:"allow_paid_broadcast,omitempty"`
-	MessageEffectID         string                          `json:"message_effect_id,omitempty"`
-	SuggestedPostParameters *models.SuggestedPostParameters `json:"suggested_post_parameters,omitempty"`
-	ReplyParameters         *models.ReplyParameters         `json:"reply_parameters,omitempty"`
-	ReplyMarkup             models.ReplyMarkup              `json:"reply_markup,omitempty"`
+	BusinessConnectionID       string                             `json:"business_connection_id,omitempty"`
+	ChatID                     any                                `json:"chat_id"`
+	MessageThreadID            int                                `json:"message_thread_id,omitempty"`
+	DirectMessagesTopicID      int                                `json:"direct_messages_topic_id,omitempty"`
+	EphemeralMessageParameters *models.EphemeralMessageParameters `json:"ephemeral_message_parameters,omitempty"`
+	Voice                      models.InputFile                   `json:"voice"`
+	Caption                    string                             `json:"caption,omitempty"`
+	ParseMode                  models.ParseMode                   `json:"parse_mode,omitempty"`
+	CaptionEntities            []models.MessageEntity             `json:"caption_entities,omitempty"`
+	Duration                   int                                `json:"duration,omitempty"`
+	DisableNotification        bool                               `json:"disable_notification,omitempty"`
+	ProtectContent             bool                               `json:"protect_content,omitempty"`
+	AllowPaidBroadcast         bool                               `json:"allow_paid_broadcast,omitempty"`
+	MessageEffectID            string                             `json:"message_effect_id,omitempty"`
+	SuggestedPostParameters    *models.SuggestedPostParameters    `json:"suggested_post_parameters,omitempty"`
+	ReplyParameters            *models.ReplyParameters            `json:"reply_parameters,omitempty"`
+	ReplyMarkup                models.ReplyMarkup                 `json:"reply_markup,omitempty"`
 }
 
 // SendVideoNoteParams https://core.telegram.org/bots/api#sendvideonote
 type SendVideoNoteParams struct {
-	BusinessConnectionID    string                          `json:"business_connection_id,omitempty"`
-	ChatID                  any                             `json:"chat_id"`
-	MessageThreadID         int                             `json:"message_thread_id,omitempty"`
-	DirectMessagesTopicID   int                             `json:"direct_messages_topic_id,omitempty"`
-	ReceiverUserID          int64                           `json:"receiver_user_id,omitempty"`
-	CallbackQueryID         string                          `json:"callback_query_id,omitempty"`
-	VideoNote               models.InputFile                `json:"video_note"`
-	Duration                int                             `json:"duration,omitempty"`
-	Length                  int                             `json:"length,omitempty"`
-	Thumbnail               models.InputFile                `json:"thumbnail,omitempty"`
-	DisableNotification     bool                            `json:"disable_notification,omitempty"`
-	ProtectContent          bool                            `json:"protect_content,omitempty"`
-	AllowPaidBroadcast      bool                            `json:"allow_paid_broadcast,omitempty"`
-	MessageEffectID         string                          `json:"message_effect_id,omitempty"`
-	SuggestedPostParameters *models.SuggestedPostParameters `json:"suggested_post_parameters,omitempty"`
-	ReplyParameters         *models.ReplyParameters         `json:"reply_parameters,omitempty"`
-	ReplyMarkup             models.ReplyMarkup              `json:"reply_markup,omitempty"`
+	BusinessConnectionID       string                             `json:"business_connection_id,omitempty"`
+	ChatID                     any                                `json:"chat_id"`
+	MessageThreadID            int                                `json:"message_thread_id,omitempty"`
+	DirectMessagesTopicID      int                                `json:"direct_messages_topic_id,omitempty"`
+	EphemeralMessageParameters *models.EphemeralMessageParameters `json:"ephemeral_message_parameters,omitempty"`
+	VideoNote                  models.InputFile                   `json:"video_note"`
+	Duration                   int                                `json:"duration,omitempty"`
+	Length                     int                                `json:"length,omitempty"`
+	Thumbnail                  models.InputFile                   `json:"thumbnail,omitempty"`
+	DisableNotification        bool                               `json:"disable_notification,omitempty"`
+	ProtectContent             bool                               `json:"protect_content,omitempty"`
+	AllowPaidBroadcast         bool                               `json:"allow_paid_broadcast,omitempty"`
+	MessageEffectID            string                             `json:"message_effect_id,omitempty"`
+	SuggestedPostParameters    *models.SuggestedPostParameters    `json:"suggested_post_parameters,omitempty"`
+	ReplyParameters            *models.ReplyParameters            `json:"reply_parameters,omitempty"`
+	ReplyMarkup                models.ReplyMarkup                 `json:"reply_markup,omitempty"`
 }
 
 // SendPaidMediaParams https://core.telegram.org/bots/api#sendpaidmedia
@@ -305,25 +297,24 @@ type SendMediaGroupParams struct {
 
 // SendLocationParams https://core.telegram.org/bots/api#sendlocation
 type SendLocationParams struct {
-	BusinessConnectionID    string                          `json:"business_connection_id,omitempty"`
-	ChatID                  any                             `json:"chat_id"`
-	MessageThreadID         int                             `json:"message_thread_id,omitempty"`
-	DirectMessagesTopicID   int                             `json:"direct_messages_topic_id,omitempty"`
-	ReceiverUserID          int64                           `json:"receiver_user_id,omitempty"`
-	CallbackQueryID         string                          `json:"callback_query_id,omitempty"`
-	Latitude                float64                         `json:"latitude"`
-	Longitude               float64                         `json:"longitude"`
-	HorizontalAccuracy      float64                         `json:"horizontal_accuracy,omitempty"`
-	LivePeriod              int                             `json:"live_period,omitempty"`
-	Heading                 int                             `json:"heading,omitempty"`
-	ProximityAlertRadius    int                             `json:"proximity_alert_radius,omitempty"`
-	DisableNotification     bool                            `json:"disable_notification,omitempty"`
-	ProtectContent          bool                            `json:"protect_content,omitempty"`
-	AllowPaidBroadcast      bool                            `json:"allow_paid_broadcast,omitempty"`
-	MessageEffectID         string                          `json:"message_effect_id,omitempty"`
-	SuggestedPostParameters *models.SuggestedPostParameters `json:"suggested_post_parameters,omitempty"`
-	ReplyParameters         *models.ReplyParameters         `json:"reply_parameters,omitempty"`
-	ReplyMarkup             models.ReplyMarkup              `json:"reply_markup,omitempty"`
+	BusinessConnectionID       string                             `json:"business_connection_id,omitempty"`
+	ChatID                     any                                `json:"chat_id"`
+	MessageThreadID            int                                `json:"message_thread_id,omitempty"`
+	DirectMessagesTopicID      int                                `json:"direct_messages_topic_id,omitempty"`
+	EphemeralMessageParameters *models.EphemeralMessageParameters `json:"ephemeral_message_parameters,omitempty"`
+	Latitude                   float64                            `json:"latitude"`
+	Longitude                  float64                            `json:"longitude"`
+	HorizontalAccuracy         float64                            `json:"horizontal_accuracy,omitempty"`
+	LivePeriod                 int                                `json:"live_period,omitempty"`
+	Heading                    int                                `json:"heading,omitempty"`
+	ProximityAlertRadius       int                                `json:"proximity_alert_radius,omitempty"`
+	DisableNotification        bool                               `json:"disable_notification,omitempty"`
+	ProtectContent             bool                               `json:"protect_content,omitempty"`
+	AllowPaidBroadcast         bool                               `json:"allow_paid_broadcast,omitempty"`
+	MessageEffectID            string                             `json:"message_effect_id,omitempty"`
+	SuggestedPostParameters    *models.SuggestedPostParameters    `json:"suggested_post_parameters,omitempty"`
+	ReplyParameters            *models.ReplyParameters            `json:"reply_parameters,omitempty"`
+	ReplyMarkup                models.ReplyMarkup                 `json:"reply_markup,omitempty"`
 }
 
 type EditMessageLiveLocationParams struct {
@@ -350,48 +341,46 @@ type StopMessageLiveLocationParams struct {
 
 // SendVenueParams https://core.telegram.org/bots/api#sendvenue
 type SendVenueParams struct {
-	BusinessConnectionID    string                          `json:"business_connection_id,omitempty"`
-	ChatID                  any                             `json:"chat_id"`
-	MessageThreadID         int                             `json:"message_thread_id,omitempty"`
-	DirectMessagesTopicID   int                             `json:"direct_messages_topic_id,omitempty"`
-	ReceiverUserID          int64                           `json:"receiver_user_id,omitempty"`
-	CallbackQueryID         string                          `json:"callback_query_id,omitempty"`
-	Latitude                float64                         `json:"latitude"`
-	Longitude               float64                         `json:"longitude"`
-	Title                   string                          `json:"title"`
-	Address                 string                          `json:"address"`
-	FoursquareID            string                          `json:"foursquare_id,omitempty"`
-	FoursquareType          string                          `json:"foursquare_type,omitempty"`
-	GooglePlaceID           string                          `json:"google_place_id,omitempty"`
-	GooglePlaceType         string                          `json:"google_place_type,omitempty"`
-	DisableNotification     bool                            `json:"disable_notification,omitempty"`
-	ProtectContent          bool                            `json:"protect_content,omitempty"`
-	AllowPaidBroadcast      bool                            `json:"allow_paid_broadcast,omitempty"`
-	MessageEffectID         string                          `json:"message_effect_id,omitempty"`
-	SuggestedPostParameters *models.SuggestedPostParameters `json:"suggested_post_parameters,omitempty"`
-	ReplyParameters         *models.ReplyParameters         `json:"reply_parameters,omitempty"`
-	ReplyMarkup             models.ReplyMarkup              `json:"reply_markup,omitempty"`
+	BusinessConnectionID       string                             `json:"business_connection_id,omitempty"`
+	ChatID                     any                                `json:"chat_id"`
+	MessageThreadID            int                                `json:"message_thread_id,omitempty"`
+	DirectMessagesTopicID      int                                `json:"direct_messages_topic_id,omitempty"`
+	EphemeralMessageParameters *models.EphemeralMessageParameters `json:"ephemeral_message_parameters,omitempty"`
+	Latitude                   float64                            `json:"latitude"`
+	Longitude                  float64                            `json:"longitude"`
+	Title                      string                             `json:"title"`
+	Address                    string                             `json:"address"`
+	FoursquareID               string                             `json:"foursquare_id,omitempty"`
+	FoursquareType             string                             `json:"foursquare_type,omitempty"`
+	GooglePlaceID              string                             `json:"google_place_id,omitempty"`
+	GooglePlaceType            string                             `json:"google_place_type,omitempty"`
+	DisableNotification        bool                               `json:"disable_notification,omitempty"`
+	ProtectContent             bool                               `json:"protect_content,omitempty"`
+	AllowPaidBroadcast         bool                               `json:"allow_paid_broadcast,omitempty"`
+	MessageEffectID            string                             `json:"message_effect_id,omitempty"`
+	SuggestedPostParameters    *models.SuggestedPostParameters    `json:"suggested_post_parameters,omitempty"`
+	ReplyParameters            *models.ReplyParameters            `json:"reply_parameters,omitempty"`
+	ReplyMarkup                models.ReplyMarkup                 `json:"reply_markup,omitempty"`
 }
 
 // SendContactParams https://core.telegram.org/bots/api#sendcontact
 type SendContactParams struct {
-	BusinessConnectionID    string                          `json:"business_connection_id,omitempty"`
-	ChatID                  any                             `json:"chat_id"`
-	MessageThreadID         int                             `json:"message_thread_id,omitempty"`
-	DirectMessagesTopicID   int                             `json:"direct_messages_topic_id,omitempty"`
-	ReceiverUserID          int64                           `json:"receiver_user_id,omitempty"`
-	CallbackQueryID         string                          `json:"callback_query_id,omitempty"`
-	PhoneNumber             string                          `json:"phone_number"`
-	FirstName               string                          `json:"first_name"`
-	LastName                string                          `json:"last_name,omitempty"`
-	VCard                   string                          `json:"vcard,omitempty"`
-	DisableNotification     bool                            `json:"disable_notification,omitempty"`
-	ProtectContent          bool                            `json:"protect_content,omitempty"`
-	AllowPaidBroadcast      bool                            `json:"allow_paid_broadcast,omitempty"`
-	MessageEffectID         string                          `json:"message_effect_id,omitempty"`
-	SuggestedPostParameters *models.SuggestedPostParameters `json:"suggested_post_parameters,omitempty"`
-	ReplyParameters         *models.ReplyParameters         `json:"reply_parameters,omitempty"`
-	ReplyMarkup             models.ReplyMarkup              `json:"reply_markup,omitempty"`
+	BusinessConnectionID       string                             `json:"business_connection_id,omitempty"`
+	ChatID                     any                                `json:"chat_id"`
+	MessageThreadID            int                                `json:"message_thread_id,omitempty"`
+	DirectMessagesTopicID      int                                `json:"direct_messages_topic_id,omitempty"`
+	EphemeralMessageParameters *models.EphemeralMessageParameters `json:"ephemeral_message_parameters,omitempty"`
+	PhoneNumber                string                             `json:"phone_number"`
+	FirstName                  string                             `json:"first_name"`
+	LastName                   string                             `json:"last_name,omitempty"`
+	VCard                      string                             `json:"vcard,omitempty"`
+	DisableNotification        bool                               `json:"disable_notification,omitempty"`
+	ProtectContent             bool                               `json:"protect_content,omitempty"`
+	AllowPaidBroadcast         bool                               `json:"allow_paid_broadcast,omitempty"`
+	MessageEffectID            string                             `json:"message_effect_id,omitempty"`
+	SuggestedPostParameters    *models.SuggestedPostParameters    `json:"suggested_post_parameters,omitempty"`
+	ReplyParameters            *models.ReplyParameters            `json:"reply_parameters,omitempty"`
+	ReplyMarkup                models.ReplyMarkup                 `json:"reply_markup,omitempty"`
 }
 
 // SendPollParams https://core.telegram.org/bots/api#sendpoll
@@ -533,6 +522,7 @@ type PromoteChatMemberParams struct {
 	CanManageTopics         bool  `json:"can_manage_topics,omitempty"`
 	CanManageDirectMessages bool  `json:"can_manage_direct_messages,omitempty"`
 	CanManageTags           bool  `json:"can_manage_tags,omitempty"`
+	CanSendWelcomeMessages  bool  `json:"can_send_welcome_messages,omitempty"`
 }
 
 type SetChatAdministratorCustomTitleParams struct {
@@ -902,9 +892,10 @@ type EditEphemeralMessageTextParams struct {
 	ChatID             any                          `json:"chat_id"`
 	ReceiverUserID     int64                        `json:"receiver_user_id"`
 	EphemeralMessageID int                          `json:"ephemeral_message_id"`
-	Text               string                       `json:"text"`
+	Text               string                       `json:"text,omitempty"`
 	ParseMode          models.ParseMode             `json:"parse_mode,omitempty"`
 	Entities           []models.MessageEntity       `json:"entities,omitempty"`
+	RichMessage        *models.InputRichMessage     `json:"rich_message,omitempty"`
 	LinkPreviewOptions *models.LinkPreviewOptions   `json:"link_preview_options,omitempty"`
 	ReplyMarkup        *models.InlineKeyboardMarkup `json:"reply_markup,omitempty"`
 }
@@ -920,13 +911,14 @@ type EditEphemeralMessageMediaParams struct {
 
 // EditEphemeralMessageCaptionParams https://core.telegram.org/bots/api#editephemeralmessagecaption
 type EditEphemeralMessageCaptionParams struct {
-	ChatID             any                          `json:"chat_id"`
-	ReceiverUserID     int64                        `json:"receiver_user_id"`
-	EphemeralMessageID int                          `json:"ephemeral_message_id"`
-	Caption            string                       `json:"caption,omitempty"`
-	ParseMode          models.ParseMode             `json:"parse_mode,omitempty"`
-	CaptionEntities    []models.MessageEntity       `json:"caption_entities,omitempty"`
-	ReplyMarkup        *models.InlineKeyboardMarkup `json:"reply_markup,omitempty"`
+	ChatID                any                          `json:"chat_id"`
+	ReceiverUserID        int64                        `json:"receiver_user_id"`
+	EphemeralMessageID    int                          `json:"ephemeral_message_id"`
+	Caption               string                       `json:"caption,omitempty"`
+	ParseMode             models.ParseMode             `json:"parse_mode,omitempty"`
+	CaptionEntities       []models.MessageEntity       `json:"caption_entities,omitempty"`
+	ShowCaptionAboveMedia bool                         `json:"show_caption_above_media,omitempty"`
+	ReplyMarkup           *models.InlineKeyboardMarkup `json:"reply_markup,omitempty"`
 }
 
 // EditEphemeralMessageReplyMarkupParams https://core.telegram.org/bots/api#editephemeralmessagereplymarkup
@@ -946,21 +938,20 @@ type DeleteEphemeralMessageParams struct {
 
 // SendStickerParams https://core.telegram.org/bots/api#sendsticker
 type SendStickerParams struct {
-	BusinessConnectionID    string                          `json:"business_connection_id,omitempty"`
-	ChatID                  any                             `json:"chat_id"`
-	MessageThreadID         int                             `json:"message_thread_id,omitempty"`
-	DirectMessagesTopicID   int                             `json:"direct_messages_topic_id,omitempty"`
-	ReceiverUserID          int64                           `json:"receiver_user_id,omitempty"`
-	CallbackQueryID         string                          `json:"callback_query_id,omitempty"`
-	Sticker                 models.InputFile                `json:"sticker"`
-	Emoji                   string                          `json:"emoji,omitempty"`
-	DisableNotification     bool                            `json:"disable_notification,omitempty"`
-	ProtectContent          bool                            `json:"protect_content,omitempty"`
-	AllowPaidBroadcast      bool                            `json:"allow_paid_broadcast,omitempty"`
-	MessageEffectID         string                          `json:"message_effect_id,omitempty"`
-	SuggestedPostParameters *models.SuggestedPostParameters `json:"suggested_post_parameters,omitempty"`
-	ReplyParameters         *models.ReplyParameters         `json:"reply_parameters,omitempty"`
-	ReplyMarkup             models.ReplyMarkup              `json:"reply_markup,omitempty"`
+	BusinessConnectionID       string                             `json:"business_connection_id,omitempty"`
+	ChatID                     any                                `json:"chat_id"`
+	MessageThreadID            int                                `json:"message_thread_id,omitempty"`
+	DirectMessagesTopicID      int                                `json:"direct_messages_topic_id,omitempty"`
+	EphemeralMessageParameters *models.EphemeralMessageParameters `json:"ephemeral_message_parameters,omitempty"`
+	Sticker                    models.InputFile                   `json:"sticker"`
+	Emoji                      string                             `json:"emoji,omitempty"`
+	DisableNotification        bool                               `json:"disable_notification,omitempty"`
+	ProtectContent             bool                               `json:"protect_content,omitempty"`
+	AllowPaidBroadcast         bool                               `json:"allow_paid_broadcast,omitempty"`
+	MessageEffectID            string                             `json:"message_effect_id,omitempty"`
+	SuggestedPostParameters    *models.SuggestedPostParameters    `json:"suggested_post_parameters,omitempty"`
+	ReplyParameters            *models.ReplyParameters            `json:"reply_parameters,omitempty"`
+	ReplyMarkup                models.ReplyMarkup                 `json:"reply_markup,omitempty"`
 }
 
 type GetStickerSetParams struct {
@@ -1390,22 +1381,25 @@ type SendMessageDraftParams struct {
 	Text                 string                 `json:"text"`
 	ParseMode            models.ParseMode       `json:"parse_mode,omitempty"`
 	Entities             []models.MessageEntity `json:"entities,omitempty"`
+	CanStop              bool                   `json:"can_stop,omitempty"`
+	KeepOnStop           bool                   `json:"keep_on_stop,omitempty"`
 }
 
 // SendRichMessageParams https://core.telegram.org/bots/api#sendrichmessage
 type SendRichMessageParams struct {
-	BusinessConnectionID    string                          `json:"business_connection_id,omitempty"`
-	ChatID                  any                             `json:"chat_id"`
-	MessageThreadID         int                             `json:"message_thread_id,omitempty"`
-	DirectMessagesTopicID   int                             `json:"direct_messages_topic_id,omitempty"`
-	RichMessage             models.InputRichMessage         `json:"rich_message"`
-	DisableNotification     bool                            `json:"disable_notification,omitempty"`
-	ProtectContent          bool                            `json:"protect_content,omitempty"`
-	AllowPaidBroadcast      bool                            `json:"allow_paid_broadcast,omitempty"`
-	MessageEffectID         string                          `json:"message_effect_id,omitempty"`
-	SuggestedPostParameters *models.SuggestedPostParameters `json:"suggested_post_parameters,omitempty"`
-	ReplyParameters         *models.ReplyParameters         `json:"reply_parameters,omitempty"`
-	ReplyMarkup             models.ReplyMarkup              `json:"reply_markup,omitempty"`
+	BusinessConnectionID       string                             `json:"business_connection_id,omitempty"`
+	ChatID                     any                                `json:"chat_id"`
+	MessageThreadID            int                                `json:"message_thread_id,omitempty"`
+	DirectMessagesTopicID      int                                `json:"direct_messages_topic_id,omitempty"`
+	EphemeralMessageParameters *models.EphemeralMessageParameters `json:"ephemeral_message_parameters,omitempty"`
+	RichMessage                models.InputRichMessage            `json:"rich_message"`
+	DisableNotification        bool                               `json:"disable_notification,omitempty"`
+	ProtectContent             bool                               `json:"protect_content,omitempty"`
+	AllowPaidBroadcast         bool                               `json:"allow_paid_broadcast,omitempty"`
+	MessageEffectID            string                             `json:"message_effect_id,omitempty"`
+	SuggestedPostParameters    *models.SuggestedPostParameters    `json:"suggested_post_parameters,omitempty"`
+	ReplyParameters            *models.ReplyParameters            `json:"reply_parameters,omitempty"`
+	ReplyMarkup                models.ReplyMarkup                 `json:"reply_markup,omitempty"`
 }
 
 // SendRichMessageDraftParams https://core.telegram.org/bots/api#sendrichmessagedraft
@@ -1414,6 +1408,8 @@ type SendRichMessageDraftParams struct {
 	MessageThreadID int                     `json:"message_thread_id,omitempty"`
 	DraftID         int                     `json:"draft_id"`
 	RichMessage     models.InputRichMessage `json:"rich_message"`
+	CanStop         bool                    `json:"can_stop,omitempty"`
+	KeepOnStop      bool                    `json:"keep_on_stop,omitempty"`
 }
 
 // RepostStoryParams https://core.telegram.org/bots/api#repoststory
@@ -1477,26 +1473,25 @@ type DeleteMessageReactionParams struct {
 }
 
 type SendLivePhotoParams struct {
-	BusinessConnectionID    string                          `json:"business_connection_id,omitempty"`
-	ChatID                  any                             `json:"chat_id"`
-	MessageThreadID         int                             `json:"message_thread_id,omitempty"`
-	DirectMessagesTopicID   int                             `json:"direct_messages_topic_id,omitempty"`
-	ReceiverUserID          int64                           `json:"receiver_user_id,omitempty"`
-	CallbackQueryID         string                          `json:"callback_query_id,omitempty"`
-	LivePhoto               models.InputFile                `json:"live_photo"`
-	Photo                   models.InputFile                `json:"photo"`
-	Caption                 string                          `json:"caption,omitempty"`
-	ParseMode               models.ParseMode                `json:"parse_mode,omitempty"`
-	CaptionEntities         []models.MessageEntity          `json:"caption_entities,omitempty"`
-	ShowCaptionAboveMedia   bool                            `json:"show_caption_above_media,omitempty"`
-	HasSpoiler              bool                            `json:"has_spoiler,omitempty"`
-	DisableNotification     bool                            `json:"disable_notification,omitempty"`
-	ProtectContent          bool                            `json:"protect_content,omitempty"`
-	AllowPaidBroadcast      bool                            `json:"allow_paid_broadcast,omitempty"`
-	MessageEffectID         string                          `json:"message_effect_id,omitempty"`
-	SuggestedPostParameters *models.SuggestedPostParameters `json:"suggested_post_parameters,omitempty"`
-	ReplyParameters         *models.ReplyParameters         `json:"reply_parameters,omitempty"`
-	ReplyMarkup             models.ReplyMarkup              `json:"reply_markup,omitempty"`
+	BusinessConnectionID       string                             `json:"business_connection_id,omitempty"`
+	ChatID                     any                                `json:"chat_id"`
+	MessageThreadID            int                                `json:"message_thread_id,omitempty"`
+	DirectMessagesTopicID      int                                `json:"direct_messages_topic_id,omitempty"`
+	EphemeralMessageParameters *models.EphemeralMessageParameters `json:"ephemeral_message_parameters,omitempty"`
+	LivePhoto                  models.InputFile                   `json:"live_photo"`
+	Photo                      models.InputFile                   `json:"photo"`
+	Caption                    string                             `json:"caption,omitempty"`
+	ParseMode                  models.ParseMode                   `json:"parse_mode,omitempty"`
+	CaptionEntities            []models.MessageEntity             `json:"caption_entities,omitempty"`
+	ShowCaptionAboveMedia      bool                               `json:"show_caption_above_media,omitempty"`
+	HasSpoiler                 bool                               `json:"has_spoiler,omitempty"`
+	DisableNotification        bool                               `json:"disable_notification,omitempty"`
+	ProtectContent             bool                               `json:"protect_content,omitempty"`
+	AllowPaidBroadcast         bool                               `json:"allow_paid_broadcast,omitempty"`
+	MessageEffectID            string                             `json:"message_effect_id,omitempty"`
+	SuggestedPostParameters    *models.SuggestedPostParameters    `json:"suggested_post_parameters,omitempty"`
+	ReplyParameters            *models.ReplyParameters            `json:"reply_parameters,omitempty"`
+	ReplyMarkup                models.ReplyMarkup                 `json:"reply_markup,omitempty"`
 }
 
 type GetManagedBotAccessSettingsParams struct {

--- a/methods_test.go
+++ b/methods_test.go
@@ -3,9 +3,11 @@ package bot
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/go-telegram/bot/models"
@@ -14,6 +16,7 @@ import (
 type httpClient struct {
 	resp      string
 	reqFields map[string]string
+	reqFiles  map[string]string // multipart file parts by name, with expected content
 	t         *testing.T
 }
 
@@ -24,6 +27,18 @@ func (c *httpClient) Do(req *http.Request) (*http.Response, error) {
 				c.t.Errorf("invalid field %q value %q, expect %q", k, req.FormValue(k), v)
 				return nil, fmt.Errorf("invalid field %q value %q, expect %q", k, req.FormValue(k), v)
 			}
+		}
+	}
+	for k, v := range c.reqFiles {
+		f, _, err := req.FormFile(k)
+		if err != nil {
+			c.t.Errorf("missing file %q: %v", k, err)
+			return nil, fmt.Errorf("missing file %q: %w", k, err)
+		}
+		data, _ := io.ReadAll(f)
+		if string(data) != v {
+			c.t.Errorf("invalid file %q content %q, expect %q", k, data, v)
+			return nil, fmt.Errorf("invalid file %q content %q, expect %q", k, data, v)
 		}
 	}
 
@@ -410,11 +425,13 @@ func TestBot_Methods(t *testing.T) {
 
 	t.Run("PromoteChatMember", func(t *testing.T) {
 		c := &httpClient{t: t, resp: `true`, reqFields: map[string]string{
-			"chat_id": "123",
+			"chat_id":                   "123",
+			"can_send_welcome_messages": "true",
 		}}
 		b := &Bot{client: c}
 		resp, err := b.PromoteChatMember(context.Background(), &PromoteChatMemberParams{
-			ChatID: 123,
+			ChatID:                 123,
+			CanSendWelcomeMessages: true,
 		})
 		assertNoErr(t, err)
 		assertTrue(t, resp)
@@ -1511,6 +1528,66 @@ func TestBot_EphemeralMessageMethods(t *testing.T) {
 		assertNoErr(t, err)
 		assertTrue(t, resp)
 	})
+
+	t.Run("EditEphemeralMessageTextRichMessage", func(t *testing.T) {
+		c := &httpClient{t: t, resp: `true`, reqFields: map[string]string{
+			"chat_id":              "123",
+			"receiver_user_id":     "9",
+			"ephemeral_message_id": "5",
+			"rich_message":         `{"html":"hello"}`,
+		}}
+		b := &Bot{client: c}
+		resp, err := b.EditEphemeralMessageText(context.Background(), &EditEphemeralMessageTextParams{
+			ChatID:             123,
+			ReceiverUserID:     9,
+			EphemeralMessageID: 5,
+			RichMessage:        &models.InputRichMessage{HTML: "hello"},
+		})
+		assertNoErr(t, err)
+		assertTrue(t, resp)
+	})
+
+	t.Run("EditEphemeralMessageCaptionShowCaptionAboveMedia", func(t *testing.T) {
+		c := &httpClient{t: t, resp: `true`, reqFields: map[string]string{
+			"chat_id":                  "123",
+			"receiver_user_id":         "9",
+			"ephemeral_message_id":     "5",
+			"caption":                  "cap",
+			"show_caption_above_media": "true",
+		}}
+		b := &Bot{client: c}
+		resp, err := b.EditEphemeralMessageCaption(context.Background(), &EditEphemeralMessageCaptionParams{
+			ChatID:                123,
+			ReceiverUserID:        9,
+			EphemeralMessageID:    5,
+			Caption:               "cap",
+			ShowCaptionAboveMedia: true,
+		})
+		assertNoErr(t, err)
+		assertTrue(t, resp)
+	})
+
+	// Bot API 10.3 allows uploading new files in editEphemeralMessageMedia; the
+	// attach:// part must reach the form alongside the media JSON.
+	t.Run("EditEphemeralMessageMediaUpload", func(t *testing.T) {
+		c := &httpClient{t: t, resp: `true`, reqFields: map[string]string{
+			"chat_id":              "123",
+			"receiver_user_id":     "9",
+			"ephemeral_message_id": "5",
+			"media":                `{"type":"photo","media":"attach://new.png"}`,
+		}, reqFiles: map[string]string{
+			"new.png": "png bytes",
+		}}
+		b := &Bot{client: c}
+		resp, err := b.EditEphemeralMessageMedia(context.Background(), &EditEphemeralMessageMediaParams{
+			ChatID:             123,
+			ReceiverUserID:     9,
+			EphemeralMessageID: 5,
+			Media:              &models.InputMediaPhoto{Media: "attach://new.png", MediaAttachment: strings.NewReader("png bytes")},
+		})
+		assertNoErr(t, err)
+		assertTrue(t, resp)
+	})
 }
 
 func TestBot_EditMessageCaption_ShowCaptionAboveMedia(t *testing.T) {
@@ -1531,4 +1608,103 @@ func TestBot_EditMessageCaption_ShowCaptionAboveMedia(t *testing.T) {
 	})
 	assertNoErr(t, err)
 	assertEqualInt(t, resp.ID, 1)
+}
+
+// TestEditEphemeralMessageTextParams_TextOptional verifies text is omitted when
+// only rich_message is given; text is required only if rich_message isn't specified.
+func TestEditEphemeralMessageTextParams_TextOptional(t *testing.T) {
+	out, err := json.Marshal(&EditEphemeralMessageTextParams{
+		ChatID:             123,
+		ReceiverUserID:     9,
+		EphemeralMessageID: 5,
+		RichMessage:        &models.InputRichMessage{HTML: "hello"},
+	})
+	assertNoErr(t, err)
+	if strings.Contains(string(out), `"text"`) {
+		t.Fatalf("text should be omitted when empty: %s", out)
+	}
+}
+
+func TestBot_EphemeralMessageParameters(t *testing.T) {
+	t.Parallel()
+
+	t.Run("SendMessage", func(t *testing.T) {
+		c := &httpClient{t: t, resp: `{"message_id":7,"date":1,"chat":{"id":123,"type":"private"}}`, reqFields: map[string]string{
+			"chat_id":                      "123",
+			"text":                         "hi",
+			"ephemeral_message_parameters": `{"receiver_user_id":9,"callback_query_id":"q","replace_callback_query_message":true}`,
+		}}
+		b := &Bot{client: c}
+		resp, err := b.SendMessage(context.Background(), &SendMessageParams{
+			ChatID: 123,
+			Text:   "hi",
+			EphemeralMessageParameters: &models.EphemeralMessageParameters{
+				ReceiverUserID:              9,
+				CallbackQueryID:             "q",
+				ReplaceCallbackQueryMessage: true,
+			},
+		})
+		assertNoErr(t, err)
+		assertEqualInt(t, 7, resp.ID)
+	})
+
+	t.Run("SendRichMessage", func(t *testing.T) {
+		c := &httpClient{t: t, resp: `{"message_id":7,"date":1,"chat":{"id":123,"type":"private"}}`, reqFields: map[string]string{
+			"chat_id":                      "123",
+			"rich_message":                 `{"html":"hello"}`,
+			"ephemeral_message_parameters": `{"receiver_user_id":9}`,
+		}}
+		b := &Bot{client: c}
+		resp, err := b.SendRichMessage(context.Background(), &SendRichMessageParams{
+			ChatID:                     123,
+			RichMessage:                models.InputRichMessage{HTML: "hello"},
+			EphemeralMessageParameters: &models.EphemeralMessageParameters{ReceiverUserID: 9},
+		})
+		assertNoErr(t, err)
+		assertEqualInt(t, 7, resp.ID)
+	})
+}
+
+func TestBot_MessageDraftMethods(t *testing.T) {
+	t.Parallel()
+
+	t.Run("SendMessageDraftCanStop", func(t *testing.T) {
+		c := &httpClient{t: t, resp: `true`, reqFields: map[string]string{
+			"chat_id":      "123",
+			"draft_id":     "1",
+			"text":         "partial",
+			"can_stop":     "true",
+			"keep_on_stop": "true",
+		}}
+		b := &Bot{client: c}
+		resp, err := b.SendMessageDraft(context.Background(), &SendMessageDraftParams{
+			ChatID:     123,
+			DraftID:    "1",
+			Text:       "partial",
+			CanStop:    true,
+			KeepOnStop: true,
+		})
+		assertNoErr(t, err)
+		assertTrue(t, resp)
+	})
+
+	t.Run("SendRichMessageDraftCanStop", func(t *testing.T) {
+		c := &httpClient{t: t, resp: `true`, reqFields: map[string]string{
+			"chat_id":      "123",
+			"draft_id":     "1",
+			"rich_message": `{"html":"hello"}`,
+			"can_stop":     "true",
+			"keep_on_stop": "true",
+		}}
+		b := &Bot{client: c}
+		resp, err := b.SendRichMessageDraft(context.Background(), &SendRichMessageDraftParams{
+			ChatID:      123,
+			DraftID:     1,
+			RichMessage: models.InputRichMessage{HTML: "hello"},
+			CanStop:     true,
+			KeepOnStop:  true,
+		})
+		assertNoErr(t, err)
+		assertTrue(t, resp)
+	})
 }

--- a/models/chat.go
+++ b/models/chat.go
@@ -50,6 +50,7 @@ type ChatAdministratorRights struct {
 	CanManageTopics         bool `json:"can_manage_topics,omitempty"`
 	CanManageDirectMessages bool `json:"can_manage_direct_messages,omitempty"`
 	CanManageTags           bool `json:"can_manage_tags,omitempty"`
+	CanSendWelcomeMessages  bool `json:"can_send_welcome_messages"`
 }
 
 // ChatPermissions https://core.telegram.org/bots/api#chatpermissions

--- a/models/chat_member.go
+++ b/models/chat_member.go
@@ -133,6 +133,7 @@ type ChatMemberAdministrator struct {
 	CanManageTopics         bool           `json:"can_manage_topics,omitempty"`
 	CanManageDirectMessages bool           `json:"can_manage_direct_messages,omitempty"`
 	CanManageTags           bool           `json:"can_manage_tags,omitempty"`
+	CanSendWelcomeMessages  bool           `json:"can_send_welcome_messages"`
 	CustomTitle             string         `json:"custom_title,omitempty"`
 }
 

--- a/models/chat_member_test.go
+++ b/models/chat_member_test.go
@@ -1,0 +1,30 @@
+package models
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestChatMemberAdministrator_CanSendWelcomeMessages verifies the 10.3 right decodes.
+func TestChatMemberAdministrator_CanSendWelcomeMessages(t *testing.T) {
+	src := `{"status":"administrator","user":{"id":1,"is_bot":false,"first_name":"A"},"can_be_edited":true,"can_send_welcome_messages":true}`
+	var cm ChatMember
+	if err := json.Unmarshal([]byte(src), &cm); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if cm.Administrator == nil || !cm.Administrator.CanSendWelcomeMessages {
+		t.Fatalf("can_send_welcome_messages not decoded: %+v", cm.Administrator)
+	}
+}
+
+// TestChatAdministratorRights_CanSendWelcomeMessages verifies the 10.3 right marshals.
+func TestChatAdministratorRights_CanSendWelcomeMessages(t *testing.T) {
+	out, err := json.Marshal(ChatAdministratorRights{CanSendWelcomeMessages: true})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(out), `"can_send_welcome_messages":true`) {
+		t.Fatalf("missing can_send_welcome_messages in %s", out)
+	}
+}

--- a/models/community.go
+++ b/models/community.go
@@ -15,6 +15,13 @@ type CommunityChatAdded struct {
 	Community Community `json:"community"`
 }
 
+// CommunityChatJoined https://core.telegram.org/bots/api#communitychatjoined
+//
+// Describes a service message about a chat being joined by a user from a community.
+type CommunityChatJoined struct {
+	Community Community `json:"community"`
+}
+
 // CommunityChatRemoved https://core.telegram.org/bots/api#communitychatremoved
 //
 // Describes a service message about a chat being removed from a community.

--- a/models/community_test.go
+++ b/models/community_test.go
@@ -88,3 +88,18 @@ func TestReplyParameters_Ephemeral(t *testing.T) {
 		t.Fatalf("message_id should be omitted when zero: %s", s)
 	}
 }
+
+// TestMessage_CommunityChatJoined verifies the 10.3 community join service message decodes.
+func TestMessage_CommunityChatJoined(t *testing.T) {
+	src := `{"message_id":1,"date":1,"chat":{"id":1,"type":"supergroup"},"community_chat_joined":{"community":{"id":555,"name":"Gophers"}}}`
+	var m Message
+	if err := json.Unmarshal([]byte(src), &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if m.CommunityChatJoined == nil {
+		t.Fatal("community_chat_joined not decoded")
+	}
+	if m.CommunityChatJoined.Community.ID != 555 || m.CommunityChatJoined.Community.Name != "Gophers" {
+		t.Fatalf("bad community: %+v", m.CommunityChatJoined.Community)
+	}
+}

--- a/models/ephemeral.go
+++ b/models/ephemeral.go
@@ -1,0 +1,10 @@
+package models
+
+// EphemeralMessageParameters https://core.telegram.org/bots/api#ephemeralmessageparameters
+//
+// Describes the parameters of an ephemeral message to send.
+type EphemeralMessageParameters struct {
+	ReceiverUserID              int64  `json:"receiver_user_id"`
+	CallbackQueryID             string `json:"callback_query_id,omitempty"`
+	ReplaceCallbackQueryMessage bool   `json:"replace_callback_query_message,omitempty"`
+}

--- a/models/ephemeral_test.go
+++ b/models/ephemeral_test.go
@@ -1,0 +1,26 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestEphemeralMessageParameters verifies the 10.3 send-side parameters marshal
+// and that the optional fields are omitted when zero.
+func TestEphemeralMessageParameters(t *testing.T) {
+	out, err := json.Marshal(EphemeralMessageParameters{ReceiverUserID: 9})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if want := `{"receiver_user_id":9}`; string(out) != want {
+		t.Fatalf("got %s, want %s", out, want)
+	}
+
+	out, err = json.Marshal(EphemeralMessageParameters{ReceiverUserID: 9, CallbackQueryID: "q", ReplaceCallbackQueryMessage: true})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if want := `{"receiver_user_id":9,"callback_query_id":"q","replace_callback_query_message":true}`; string(out) != want {
+		t.Fatalf("got %s, want %s", out, want)
+	}
+}

--- a/models/gift.go
+++ b/models/gift.go
@@ -197,11 +197,14 @@ type GiftInfo struct {
 
 // UniqueGiftInfo https://core.telegram.org/bots/api#uniquegiftinfo
 type UniqueGiftInfo struct {
-	Gift               UniqueGift `json:"gift"`
-	Origin             string     `json:"origin"`
-	LastResaleCurrency string     `json:"last_resale_currency,omitempty"`
-	LastResaleAmount   int        `json:"last_resale_amount,omitempty"`
-	OwnedGiftID        string     `json:"owned_gift_id,omitempty"`
-	TransferStarCount  int        `json:"transfer_star_count,omitempty"`
-	NextTransferDate   int        `json:"next_transfer_date,omitempty"`
+	Gift               UniqueGift      `json:"gift"`
+	Origin             string          `json:"origin"`
+	Text               string          `json:"text,omitempty"`
+	Entities           []MessageEntity `json:"entities,omitempty"`
+	IsPrivate          bool            `json:"is_private,omitempty"`
+	LastResaleCurrency string          `json:"last_resale_currency,omitempty"`
+	LastResaleAmount   int             `json:"last_resale_amount,omitempty"`
+	OwnedGiftID        string          `json:"owned_gift_id,omitempty"`
+	TransferStarCount  int             `json:"transfer_star_count,omitempty"`
+	NextTransferDate   int             `json:"next_transfer_date,omitempty"`
 }

--- a/models/gift_test.go
+++ b/models/gift_test.go
@@ -1,0 +1,24 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestUniqueGiftInfo_Text verifies the 10.3 text, entities and is_private fields decode.
+func TestUniqueGiftInfo_Text(t *testing.T) {
+	src := `{"gift":{"gift_id":"g","base_name":"b","name":"n","number":1},"origin":"transfer","text":"hi","entities":[{"type":"bold","offset":0,"length":2}],"is_private":true}`
+	var info UniqueGiftInfo
+	if err := json.Unmarshal([]byte(src), &info); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if info.Text != "hi" {
+		t.Fatalf("text = %q", info.Text)
+	}
+	if len(info.Entities) != 1 || info.Entities[0].Type != "bold" {
+		t.Fatalf("entities not decoded: %+v", info.Entities)
+	}
+	if !info.IsPrivate {
+		t.Fatal("is_private not decoded")
+	}
+}

--- a/models/input_rich_block.go
+++ b/models/input_rich_block.go
@@ -13,27 +13,30 @@ import (
 type InputRichBlock struct {
 	Type RichBlockType
 
-	InputRichBlockParagraph              *InputRichBlockParagraph
-	InputRichBlockSectionHeading         *InputRichBlockSectionHeading
-	InputRichBlockPreformatted           *InputRichBlockPreformatted
-	InputRichBlockFooter                 *InputRichBlockFooter
-	InputRichBlockDivider                *InputRichBlockDivider
-	InputRichBlockMathematicalExpression *InputRichBlockMathematicalExpression
-	InputRichBlockAnchor                 *InputRichBlockAnchor
-	InputRichBlockList                   *InputRichBlockList
-	InputRichBlockBlockQuotation         *InputRichBlockBlockQuotation
-	InputRichBlockPullQuotation          *InputRichBlockPullQuotation
-	InputRichBlockCollage                *InputRichBlockCollage
-	InputRichBlockSlideshow              *InputRichBlockSlideshow
-	InputRichBlockTable                  *InputRichBlockTable
-	InputRichBlockDetails                *InputRichBlockDetails
-	InputRichBlockMap                    *InputRichBlockMap
-	InputRichBlockAnimation              *InputRichBlockAnimation
-	InputRichBlockAudio                  *InputRichBlockAudio
-	InputRichBlockPhoto                  *InputRichBlockPhoto
-	InputRichBlockVideo                  *InputRichBlockVideo
-	InputRichBlockVoiceNote              *InputRichBlockVoiceNote
-	InputRichBlockThinking               *InputRichBlockThinking
+	InputRichBlockParagraph                *InputRichBlockParagraph
+	InputRichBlockSectionHeading           *InputRichBlockSectionHeading
+	InputRichBlockPreformatted             *InputRichBlockPreformatted
+	InputRichBlockFooter                   *InputRichBlockFooter
+	InputRichBlockDivider                  *InputRichBlockDivider
+	InputRichBlockMathematicalExpression   *InputRichBlockMathematicalExpression
+	InputRichBlockAnchor                   *InputRichBlockAnchor
+	InputRichBlockList                     *InputRichBlockList
+	InputRichBlockBlockQuotation           *InputRichBlockBlockQuotation
+	InputRichBlockExpandableBlockQuotation *InputRichBlockExpandableBlockQuotation
+	InputRichBlockPullQuotation            *InputRichBlockPullQuotation
+	InputRichBlockCollage                  *InputRichBlockCollage
+	InputRichBlockSlideshow                *InputRichBlockSlideshow
+	InputRichBlockTable                    *InputRichBlockTable
+	InputRichBlockDetails                  *InputRichBlockDetails
+	InputRichBlockMap                      *InputRichBlockMap
+	InputRichBlockButtons                  *InputRichBlockButtons
+	InputRichBlockAnimation                *InputRichBlockAnimation
+	InputRichBlockAudio                    *InputRichBlockAudio
+	InputRichBlockDocument                 *InputRichBlockDocument
+	InputRichBlockPhoto                    *InputRichBlockPhoto
+	InputRichBlockVideo                    *InputRichBlockVideo
+	InputRichBlockVoiceNote                *InputRichBlockVoiceNote
+	InputRichBlockThinking                 *InputRichBlockThinking
 }
 
 // MarshalJSON implements json.Marshaler. The value receiver ensures the encoding
@@ -58,6 +61,8 @@ func (rb InputRichBlock) MarshalJSON() ([]byte, error) {
 		return marshalVariant("InputRichBlock", rb.Type, rb.InputRichBlockList, func(v *InputRichBlockList) { v.Type = rb.Type })
 	case RichBlockTypeBlockQuotation:
 		return marshalVariant("InputRichBlock", rb.Type, rb.InputRichBlockBlockQuotation, func(v *InputRichBlockBlockQuotation) { v.Type = rb.Type })
+	case RichBlockTypeExpandableBlockQuotation:
+		return marshalVariant("InputRichBlock", rb.Type, rb.InputRichBlockExpandableBlockQuotation, func(v *InputRichBlockExpandableBlockQuotation) { v.Type = rb.Type })
 	case RichBlockTypePullQuotation:
 		return marshalVariant("InputRichBlock", rb.Type, rb.InputRichBlockPullQuotation, func(v *InputRichBlockPullQuotation) { v.Type = rb.Type })
 	case RichBlockTypeCollage:
@@ -70,10 +75,14 @@ func (rb InputRichBlock) MarshalJSON() ([]byte, error) {
 		return marshalVariant("InputRichBlock", rb.Type, rb.InputRichBlockDetails, func(v *InputRichBlockDetails) { v.Type = rb.Type })
 	case RichBlockTypeMap:
 		return marshalVariant("InputRichBlock", rb.Type, rb.InputRichBlockMap, func(v *InputRichBlockMap) { v.Type = rb.Type })
+	case RichBlockTypeButtons:
+		return marshalVariant("InputRichBlock", rb.Type, rb.InputRichBlockButtons, func(v *InputRichBlockButtons) { v.Type = rb.Type })
 	case RichBlockTypeAnimation:
 		return marshalVariant("InputRichBlock", rb.Type, rb.InputRichBlockAnimation, func(v *InputRichBlockAnimation) { v.Type = rb.Type })
 	case RichBlockTypeAudio:
 		return marshalVariant("InputRichBlock", rb.Type, rb.InputRichBlockAudio, func(v *InputRichBlockAudio) { v.Type = rb.Type })
+	case RichBlockTypeDocument:
+		return marshalVariant("InputRichBlock", rb.Type, rb.InputRichBlockDocument, func(v *InputRichBlockDocument) { v.Type = rb.Type })
 	case RichBlockTypePhoto:
 		return marshalVariant("InputRichBlock", rb.Type, rb.InputRichBlockPhoto, func(v *InputRichBlockPhoto) { v.Type = rb.Type })
 	case RichBlockTypeVideo:
@@ -132,6 +141,10 @@ func (rb *InputRichBlock) UnmarshalJSON(data []byte) error {
 		rb.Type = RichBlockTypeBlockQuotation
 		rb.InputRichBlockBlockQuotation = &InputRichBlockBlockQuotation{}
 		return json.Unmarshal(data, rb.InputRichBlockBlockQuotation)
+	case RichBlockTypeExpandableBlockQuotation:
+		rb.Type = RichBlockTypeExpandableBlockQuotation
+		rb.InputRichBlockExpandableBlockQuotation = &InputRichBlockExpandableBlockQuotation{}
+		return json.Unmarshal(data, rb.InputRichBlockExpandableBlockQuotation)
 	case RichBlockTypePullQuotation:
 		rb.Type = RichBlockTypePullQuotation
 		rb.InputRichBlockPullQuotation = &InputRichBlockPullQuotation{}
@@ -156,6 +169,10 @@ func (rb *InputRichBlock) UnmarshalJSON(data []byte) error {
 		rb.Type = RichBlockTypeMap
 		rb.InputRichBlockMap = &InputRichBlockMap{}
 		return json.Unmarshal(data, rb.InputRichBlockMap)
+	case RichBlockTypeButtons:
+		rb.Type = RichBlockTypeButtons
+		rb.InputRichBlockButtons = &InputRichBlockButtons{}
+		return json.Unmarshal(data, rb.InputRichBlockButtons)
 	case RichBlockTypeAnimation:
 		rb.Type = RichBlockTypeAnimation
 		rb.InputRichBlockAnimation = &InputRichBlockAnimation{}
@@ -164,6 +181,10 @@ func (rb *InputRichBlock) UnmarshalJSON(data []byte) error {
 		rb.Type = RichBlockTypeAudio
 		rb.InputRichBlockAudio = &InputRichBlockAudio{}
 		return json.Unmarshal(data, rb.InputRichBlockAudio)
+	case RichBlockTypeDocument:
+		rb.Type = RichBlockTypeDocument
+		rb.InputRichBlockDocument = &InputRichBlockDocument{}
+		return json.Unmarshal(data, rb.InputRichBlockDocument)
 	case RichBlockTypePhoto:
 		rb.Type = RichBlockTypePhoto
 		rb.InputRichBlockPhoto = &InputRichBlockPhoto{}
@@ -252,6 +273,13 @@ type InputRichBlockBlockQuotation struct {
 	Credit *RichText        `json:"credit,omitempty"`
 }
 
+// InputRichBlockExpandableBlockQuotation https://core.telegram.org/bots/api#inputrichblockexpandableblockquotation
+type InputRichBlockExpandableBlockQuotation struct {
+	Type   RichBlockType `json:"type"` // always "expandable_blockquote"
+	Text   RichText      `json:"text"`
+	Credit *RichText     `json:"credit,omitempty"`
+}
+
 // InputRichBlockPullQuotation https://core.telegram.org/bots/api#inputrichblockpullquotation
 type InputRichBlockPullQuotation struct {
 	Type   RichBlockType `json:"type"` // always "pullquote"
@@ -279,6 +307,7 @@ type InputRichBlockTable struct {
 	Cells      [][]RichBlockTableCell `json:"cells"`
 	IsBordered bool                   `json:"is_bordered,omitempty"`
 	IsStriped  bool                   `json:"is_striped,omitempty"`
+	IsCompact  bool                   `json:"is_compact,omitempty"`
 	Caption    *RichText              `json:"caption,omitempty"`
 }
 
@@ -300,6 +329,13 @@ type InputRichBlockMap struct {
 	Caption  *RichBlockCaption `json:"caption,omitempty"`
 }
 
+// InputRichBlockButtons https://core.telegram.org/bots/api#inputrichblockbuttons
+type InputRichBlockButtons struct {
+	Type    RichBlockType       `json:"type"` // always "buttons"
+	Buttons []RichMessageButton `json:"buttons"`
+	Align   string              `json:"align,omitempty"`
+}
+
 // InputRichBlockAnimation https://core.telegram.org/bots/api#inputrichblockanimation
 type InputRichBlockAnimation struct {
 	Type      RichBlockType       `json:"type"` // always "animation"
@@ -312,6 +348,13 @@ type InputRichBlockAudio struct {
 	Type    RichBlockType     `json:"type"` // always "audio"
 	Audio   InputMediaAudio   `json:"audio"`
 	Caption *RichBlockCaption `json:"caption,omitempty"`
+}
+
+// InputRichBlockDocument https://core.telegram.org/bots/api#inputrichblockdocument
+type InputRichBlockDocument struct {
+	Type     RichBlockType      `json:"type"` // always "document"
+	Document InputMediaDocument `json:"document"`
+	Caption  *RichBlockCaption  `json:"caption,omitempty"`
 }
 
 // InputRichBlockPhoto https://core.telegram.org/bots/api#inputrichblockphoto

--- a/models/input_rich_block_test.go
+++ b/models/input_rich_block_test.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"encoding/json"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -212,5 +213,69 @@ func TestInputRichBlockTable_IsCompact(t *testing.T) {
 	}
 	if !strings.Contains(string(out), `"is_compact":true`) {
 		t.Fatalf("expected is_compact in %s", out)
+	}
+}
+
+// TestInputRichBlock_Unmarshal verifies every union tag decodes into its
+// matching variant pointer.
+func TestInputRichBlock_Unmarshal(t *testing.T) {
+	cases := []struct {
+		typ     RichBlockType
+		variant func(rb *InputRichBlock) any
+	}{
+		{RichBlockTypeParagraph, func(rb *InputRichBlock) any { return rb.InputRichBlockParagraph }},
+		{RichBlockTypeSectionHeading, func(rb *InputRichBlock) any { return rb.InputRichBlockSectionHeading }},
+		{RichBlockTypePreformatted, func(rb *InputRichBlock) any { return rb.InputRichBlockPreformatted }},
+		{RichBlockTypeFooter, func(rb *InputRichBlock) any { return rb.InputRichBlockFooter }},
+		{RichBlockTypeDivider, func(rb *InputRichBlock) any { return rb.InputRichBlockDivider }},
+		{RichBlockTypeMathematicalExpression, func(rb *InputRichBlock) any { return rb.InputRichBlockMathematicalExpression }},
+		{RichBlockTypeAnchor, func(rb *InputRichBlock) any { return rb.InputRichBlockAnchor }},
+		{RichBlockTypeList, func(rb *InputRichBlock) any { return rb.InputRichBlockList }},
+		{RichBlockTypeBlockQuotation, func(rb *InputRichBlock) any { return rb.InputRichBlockBlockQuotation }},
+		{RichBlockTypeExpandableBlockQuotation, func(rb *InputRichBlock) any { return rb.InputRichBlockExpandableBlockQuotation }},
+		{RichBlockTypePullQuotation, func(rb *InputRichBlock) any { return rb.InputRichBlockPullQuotation }},
+		{RichBlockTypeCollage, func(rb *InputRichBlock) any { return rb.InputRichBlockCollage }},
+		{RichBlockTypeSlideshow, func(rb *InputRichBlock) any { return rb.InputRichBlockSlideshow }},
+		{RichBlockTypeTable, func(rb *InputRichBlock) any { return rb.InputRichBlockTable }},
+		{RichBlockTypeDetails, func(rb *InputRichBlock) any { return rb.InputRichBlockDetails }},
+		{RichBlockTypeMap, func(rb *InputRichBlock) any { return rb.InputRichBlockMap }},
+		{RichBlockTypeButtons, func(rb *InputRichBlock) any { return rb.InputRichBlockButtons }},
+		{RichBlockTypeAnimation, func(rb *InputRichBlock) any { return rb.InputRichBlockAnimation }},
+		{RichBlockTypeAudio, func(rb *InputRichBlock) any { return rb.InputRichBlockAudio }},
+		{RichBlockTypeDocument, func(rb *InputRichBlock) any { return rb.InputRichBlockDocument }},
+		{RichBlockTypePhoto, func(rb *InputRichBlock) any { return rb.InputRichBlockPhoto }},
+		{RichBlockTypeVideo, func(rb *InputRichBlock) any { return rb.InputRichBlockVideo }},
+		{RichBlockTypeVoiceNote, func(rb *InputRichBlock) any { return rb.InputRichBlockVoiceNote }},
+		{RichBlockTypeThinking, func(rb *InputRichBlock) any { return rb.InputRichBlockThinking }},
+	}
+	for _, c := range cases {
+		t.Run(string(c.typ), func(t *testing.T) {
+			var rb InputRichBlock
+			if err := json.Unmarshal([]byte(`{"type":"`+string(c.typ)+`"}`), &rb); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if rb.Type != c.typ {
+				t.Fatalf("got type %q, want %q", rb.Type, c.typ)
+			}
+			if v := c.variant(&rb); v == nil || reflect.ValueOf(v).IsNil() {
+				t.Fatalf("variant pointer not set for %q", c.typ)
+			}
+		})
+	}
+}
+
+// TestInputRichBlock_UnmarshalErrors verifies malformed input and unknown
+// discriminators are reported instead of silently producing an empty block.
+func TestInputRichBlock_UnmarshalErrors(t *testing.T) {
+	var rb InputRichBlock
+	if err := rb.UnmarshalJSON([]byte(`{"type":123}`)); err == nil {
+		t.Fatal("expected error for non-string type")
+	}
+	err := rb.UnmarshalJSON([]byte(`{"type":"definitely_not_a_real_type"}`))
+	if err == nil {
+		t.Fatal("expected error for unknown block type")
+	}
+	if !strings.Contains(err.Error(), `unsupported InputRichBlock type "definitely_not_a_real_type"`) {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/models/input_rich_block_test.go
+++ b/models/input_rich_block_test.go
@@ -19,6 +19,9 @@ func TestInputRichBlock_Marshal(t *testing.T) {
 		{"divider", InputRichBlock{Type: RichBlockTypeDivider, InputRichBlockDivider: &InputRichBlockDivider{}}, "divider"},
 		{"math", InputRichBlock{Type: RichBlockTypeMathematicalExpression, InputRichBlockMathematicalExpression: &InputRichBlockMathematicalExpression{Expression: "x^2"}}, "mathematical_expression"},
 		{"thinking", InputRichBlock{Type: RichBlockTypeThinking, InputRichBlockThinking: &InputRichBlockThinking{Text: RichText{PlainText: "reasoning"}}}, "thinking"},
+		{"expandable_blockquote", InputRichBlock{Type: RichBlockTypeExpandableBlockQuotation, InputRichBlockExpandableBlockQuotation: &InputRichBlockExpandableBlockQuotation{Text: RichText{PlainText: "q"}}}, "expandable_blockquote"},
+		{"buttons", InputRichBlock{Type: RichBlockTypeButtons, InputRichBlockButtons: &InputRichBlockButtons{Buttons: []RichMessageButton{{Text: RichText{PlainText: "Go"}, CallbackData: "go"}}, Align: "right"}}, "buttons"},
+		{"document", InputRichBlock{Type: RichBlockTypeDocument, InputRichBlockDocument: &InputRichBlockDocument{Document: InputMediaDocument{Media: "d"}}}, "document"},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -181,5 +184,33 @@ func TestInputRichBlock_MarshalDoesNotMutate(t *testing.T) {
 	}
 	if variant.Type != "" {
 		t.Fatalf("marshal mutated the caller's variant: Type = %q", variant.Type)
+	}
+}
+
+// TestInputRichBlockDocument_NestedMediaType verifies the InputMediaDocument
+// nested in a document block carries its type discriminator.
+func TestInputRichBlockDocument_NestedMediaType(t *testing.T) {
+	block := InputRichBlock{Type: RichBlockTypeDocument, InputRichBlockDocument: &InputRichBlockDocument{Document: InputMediaDocument{Media: "d"}}}
+	out, err := json.Marshal(block)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(out), `"document":{"type":"document"`) {
+		t.Fatalf("expected nested document type in %s", out)
+	}
+}
+
+// TestInputRichBlockTable_IsCompact verifies the 10.3 is_compact flag on tables.
+func TestInputRichBlockTable_IsCompact(t *testing.T) {
+	block := InputRichBlock{Type: RichBlockTypeTable, InputRichBlockTable: &InputRichBlockTable{
+		Cells:     [][]RichBlockTableCell{{{Align: "left", Valign: "top"}}},
+		IsCompact: true,
+	}}
+	out, err := json.Marshal(block)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(out), `"is_compact":true`) {
+		t.Fatalf("expected is_compact in %s", out)
 	}
 }

--- a/models/message.go
+++ b/models/message.go
@@ -179,6 +179,7 @@ type Message struct {
 	ChatOwnerLeft                 *ChatOwnerLeft                 `json:"chat_owner_left,omitempty"`
 	ChatOwnerChanged              *ChatOwnerChanged              `json:"chat_owner_changed,omitempty"`
 	CommunityChatAdded            *CommunityChatAdded            `json:"community_chat_added,omitempty"`
+	CommunityChatJoined           *CommunityChatJoined           `json:"community_chat_joined,omitempty"`
 	CommunityChatRemoved          *CommunityChatRemoved          `json:"community_chat_removed,omitempty"`
 	SuggestedPostApproved         *SuggestedPostApproved         `json:"suggested_post_approved,omitempty"`
 	SuggestedPostApprovalFailed   *SuggestedPostApprovalFailed   `json:"suggested_post_approval_failed,omitempty"`

--- a/models/message_generation.go
+++ b/models/message_generation.go
@@ -1,0 +1,10 @@
+package models
+
+// MessageGenerationStopped https://core.telegram.org/bots/api#messagegenerationstopped
+//
+// Describes an update about a user stopping message generation.
+type MessageGenerationStopped struct {
+	Chat            Chat `json:"chat"`
+	MessageThreadID int  `json:"message_thread_id,omitempty"`
+	DraftID         int  `json:"draft_id"`
+}

--- a/models/message_generation_test.go
+++ b/models/message_generation_test.go
@@ -1,0 +1,21 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestUpdate_StoppedMessageGeneration verifies the 10.3 Update field decodes.
+func TestUpdate_StoppedMessageGeneration(t *testing.T) {
+	src := `{"update_id":1,"stopped_message_generation":{"chat":{"id":5,"type":"private"},"message_thread_id":3,"draft_id":42}}`
+	var u Update
+	if err := json.Unmarshal([]byte(src), &u); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if u.StoppedMessageGeneration == nil {
+		t.Fatal("stopped_message_generation not decoded")
+	}
+	if u.StoppedMessageGeneration.Chat.ID != 5 || u.StoppedMessageGeneration.MessageThreadID != 3 || u.StoppedMessageGeneration.DraftID != 42 {
+		t.Fatalf("bad update: %+v", u.StoppedMessageGeneration)
+	}
+}

--- a/models/reply_markup.go
+++ b/models/reply_markup.go
@@ -5,6 +5,7 @@ type ReplyMarkup any
 // InlineKeyboardMarkup https://core.telegram.org/bots/api#inlinekeyboardmarkup
 type InlineKeyboardMarkup struct {
 	InlineKeyboard [][]InlineKeyboardButton `json:"inline_keyboard"`
+	ForceReply     bool                     `json:"force_reply,omitempty"`
 }
 
 // LoginURL https://core.telegram.org/bots/api#loginurl
@@ -29,6 +30,11 @@ type CopyTextButton struct {
 	Text string `json:"text"`
 }
 
+// DisabledButton https://core.telegram.org/bots/api#disabledbutton
+//
+// Represents a disabled button which does nothing. Currently holds no information.
+type DisabledButton struct{}
+
 // InlineKeyboardButton https://core.telegram.org/bots/api#inlinekeyboardbutton
 type InlineKeyboardButton struct {
 	Text                         string                       `json:"text"`
@@ -44,6 +50,7 @@ type InlineKeyboardButton struct {
 	CopyText                     *CopyTextButton              `json:"copy_text,omitempty"`
 	CallbackGame                 *CallbackGame                `json:"callback_game,omitempty"`
 	Pay                          bool                         `json:"pay,omitempty"`
+	Disabled                     *DisabledButton              `json:"disabled,omitempty"`
 }
 
 // ReplyKeyboardMarkup https://core.telegram.org/bots/api#replykeyboardmarkup
@@ -54,6 +61,7 @@ type ReplyKeyboardMarkup struct {
 	OneTimeKeyboard       bool               `json:"one_time_keyboard,omitempty"`
 	InputFieldPlaceholder string             `json:"input_field_placeholder,omitempty"`
 	Selective             bool               `json:"selective,omitempty"`
+	ForceReply            bool               `json:"force_reply,omitempty"`
 }
 
 // KeyboardButton https://core.telegram.org/bots/api#keyboardbutton

--- a/models/reply_markup_test.go
+++ b/models/reply_markup_test.go
@@ -1,0 +1,53 @@
+package models
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestInlineKeyboardButton_Disabled verifies a disabled button is encoded as an
+// empty object, which is how Telegram represents DisabledButton.
+func TestInlineKeyboardButton_Disabled(t *testing.T) {
+	out, err := json.Marshal(InlineKeyboardButton{Text: "Off", Disabled: &DisabledButton{}})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if want := `{"text":"Off","disabled":{}}`; string(out) != want {
+		t.Fatalf("got %s, want %s", out, want)
+	}
+}
+
+// TestInlineKeyboardMarkup_ForceReply verifies the 10.3 force_reply flag is sent
+// only when set.
+func TestInlineKeyboardMarkup_ForceReply(t *testing.T) {
+	out, err := json.Marshal(InlineKeyboardMarkup{InlineKeyboard: [][]InlineKeyboardButton{}, ForceReply: true})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(out), `"force_reply":true`) {
+		t.Fatalf("missing force_reply in %s", out)
+	}
+
+	out, _ = json.Marshal(InlineKeyboardMarkup{InlineKeyboard: [][]InlineKeyboardButton{}})
+	if strings.Contains(string(out), `"force_reply"`) {
+		t.Fatalf("force_reply should be omitted when false: %s", out)
+	}
+}
+
+// TestReplyKeyboardMarkup_ForceReply verifies the 10.3 force_reply flag is sent
+// only when set.
+func TestReplyKeyboardMarkup_ForceReply(t *testing.T) {
+	out, err := json.Marshal(ReplyKeyboardMarkup{Keyboard: [][]KeyboardButton{}, ForceReply: true})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(out), `"force_reply":true`) {
+		t.Fatalf("missing force_reply in %s", out)
+	}
+
+	out, _ = json.Marshal(ReplyKeyboardMarkup{Keyboard: [][]KeyboardButton{}})
+	if strings.Contains(string(out), `"force_reply"`) {
+		t.Fatalf("force_reply should be omitted when false: %s", out)
+	}
+}

--- a/models/rich_block.go
+++ b/models/rich_block.go
@@ -9,27 +9,30 @@ import (
 type RichBlockType string
 
 const (
-	RichBlockTypeParagraph              RichBlockType = "paragraph"
-	RichBlockTypeSectionHeading         RichBlockType = "heading"
-	RichBlockTypePreformatted           RichBlockType = "pre"
-	RichBlockTypeFooter                 RichBlockType = "footer"
-	RichBlockTypeDivider                RichBlockType = "divider"
-	RichBlockTypeMathematicalExpression RichBlockType = "mathematical_expression"
-	RichBlockTypeAnchor                 RichBlockType = "anchor"
-	RichBlockTypeList                   RichBlockType = "list"
-	RichBlockTypeBlockQuotation         RichBlockType = "blockquote"
-	RichBlockTypePullQuotation          RichBlockType = "pullquote"
-	RichBlockTypeCollage                RichBlockType = "collage"
-	RichBlockTypeSlideshow              RichBlockType = "slideshow"
-	RichBlockTypeTable                  RichBlockType = "table"
-	RichBlockTypeDetails                RichBlockType = "details"
-	RichBlockTypeMap                    RichBlockType = "map"
-	RichBlockTypeAnimation              RichBlockType = "animation"
-	RichBlockTypeAudio                  RichBlockType = "audio"
-	RichBlockTypePhoto                  RichBlockType = "photo"
-	RichBlockTypeVideo                  RichBlockType = "video"
-	RichBlockTypeVoiceNote              RichBlockType = "voice_note"
-	RichBlockTypeThinking               RichBlockType = "thinking"
+	RichBlockTypeParagraph                RichBlockType = "paragraph"
+	RichBlockTypeSectionHeading           RichBlockType = "heading"
+	RichBlockTypePreformatted             RichBlockType = "pre"
+	RichBlockTypeFooter                   RichBlockType = "footer"
+	RichBlockTypeDivider                  RichBlockType = "divider"
+	RichBlockTypeMathematicalExpression   RichBlockType = "mathematical_expression"
+	RichBlockTypeAnchor                   RichBlockType = "anchor"
+	RichBlockTypeList                     RichBlockType = "list"
+	RichBlockTypeBlockQuotation           RichBlockType = "blockquote"
+	RichBlockTypeExpandableBlockQuotation RichBlockType = "expandable_blockquote"
+	RichBlockTypePullQuotation            RichBlockType = "pullquote"
+	RichBlockTypeCollage                  RichBlockType = "collage"
+	RichBlockTypeSlideshow                RichBlockType = "slideshow"
+	RichBlockTypeTable                    RichBlockType = "table"
+	RichBlockTypeDetails                  RichBlockType = "details"
+	RichBlockTypeMap                      RichBlockType = "map"
+	RichBlockTypeButtons                  RichBlockType = "buttons"
+	RichBlockTypeAnimation                RichBlockType = "animation"
+	RichBlockTypeAudio                    RichBlockType = "audio"
+	RichBlockTypeDocument                 RichBlockType = "document"
+	RichBlockTypePhoto                    RichBlockType = "photo"
+	RichBlockTypeVideo                    RichBlockType = "video"
+	RichBlockTypeVoiceNote                RichBlockType = "voice_note"
+	RichBlockTypeThinking                 RichBlockType = "thinking"
 )
 
 // RichBlock https://core.telegram.org/bots/api#richblock
@@ -39,27 +42,30 @@ const (
 type RichBlock struct {
 	Type RichBlockType
 
-	RichBlockParagraph              *RichBlockParagraph
-	RichBlockSectionHeading         *RichBlockSectionHeading
-	RichBlockPreformatted           *RichBlockPreformatted
-	RichBlockFooter                 *RichBlockFooter
-	RichBlockDivider                *RichBlockDivider
-	RichBlockMathematicalExpression *RichBlockMathematicalExpression
-	RichBlockAnchor                 *RichBlockAnchor
-	RichBlockList                   *RichBlockList
-	RichBlockBlockQuotation         *RichBlockBlockQuotation
-	RichBlockPullQuotation          *RichBlockPullQuotation
-	RichBlockCollage                *RichBlockCollage
-	RichBlockSlideshow              *RichBlockSlideshow
-	RichBlockTable                  *RichBlockTable
-	RichBlockDetails                *RichBlockDetails
-	RichBlockMap                    *RichBlockMap
-	RichBlockAnimation              *RichBlockAnimation
-	RichBlockAudio                  *RichBlockAudio
-	RichBlockPhoto                  *RichBlockPhoto
-	RichBlockVideo                  *RichBlockVideo
-	RichBlockVoiceNote              *RichBlockVoiceNote
-	RichBlockThinking               *RichBlockThinking
+	RichBlockParagraph                *RichBlockParagraph
+	RichBlockSectionHeading           *RichBlockSectionHeading
+	RichBlockPreformatted             *RichBlockPreformatted
+	RichBlockFooter                   *RichBlockFooter
+	RichBlockDivider                  *RichBlockDivider
+	RichBlockMathematicalExpression   *RichBlockMathematicalExpression
+	RichBlockAnchor                   *RichBlockAnchor
+	RichBlockList                     *RichBlockList
+	RichBlockBlockQuotation           *RichBlockBlockQuotation
+	RichBlockExpandableBlockQuotation *RichBlockExpandableBlockQuotation
+	RichBlockPullQuotation            *RichBlockPullQuotation
+	RichBlockCollage                  *RichBlockCollage
+	RichBlockSlideshow                *RichBlockSlideshow
+	RichBlockTable                    *RichBlockTable
+	RichBlockDetails                  *RichBlockDetails
+	RichBlockMap                      *RichBlockMap
+	RichBlockButtons                  *RichBlockButtons
+	RichBlockAnimation                *RichBlockAnimation
+	RichBlockAudio                    *RichBlockAudio
+	RichBlockDocument                 *RichBlockDocument
+	RichBlockPhoto                    *RichBlockPhoto
+	RichBlockVideo                    *RichBlockVideo
+	RichBlockVoiceNote                *RichBlockVoiceNote
+	RichBlockThinking                 *RichBlockThinking
 }
 
 // MarshalJSON implements json.Marshaler. The value receiver ensures the encoding
@@ -84,6 +90,8 @@ func (rb RichBlock) MarshalJSON() ([]byte, error) {
 		return marshalVariant("RichBlock", rb.Type, rb.RichBlockList, func(v *RichBlockList) { v.Type = rb.Type })
 	case RichBlockTypeBlockQuotation:
 		return marshalVariant("RichBlock", rb.Type, rb.RichBlockBlockQuotation, func(v *RichBlockBlockQuotation) { v.Type = rb.Type })
+	case RichBlockTypeExpandableBlockQuotation:
+		return marshalVariant("RichBlock", rb.Type, rb.RichBlockExpandableBlockQuotation, func(v *RichBlockExpandableBlockQuotation) { v.Type = rb.Type })
 	case RichBlockTypePullQuotation:
 		return marshalVariant("RichBlock", rb.Type, rb.RichBlockPullQuotation, func(v *RichBlockPullQuotation) { v.Type = rb.Type })
 	case RichBlockTypeCollage:
@@ -96,10 +104,14 @@ func (rb RichBlock) MarshalJSON() ([]byte, error) {
 		return marshalVariant("RichBlock", rb.Type, rb.RichBlockDetails, func(v *RichBlockDetails) { v.Type = rb.Type })
 	case RichBlockTypeMap:
 		return marshalVariant("RichBlock", rb.Type, rb.RichBlockMap, func(v *RichBlockMap) { v.Type = rb.Type })
+	case RichBlockTypeButtons:
+		return marshalVariant("RichBlock", rb.Type, rb.RichBlockButtons, func(v *RichBlockButtons) { v.Type = rb.Type })
 	case RichBlockTypeAnimation:
 		return marshalVariant("RichBlock", rb.Type, rb.RichBlockAnimation, func(v *RichBlockAnimation) { v.Type = rb.Type })
 	case RichBlockTypeAudio:
 		return marshalVariant("RichBlock", rb.Type, rb.RichBlockAudio, func(v *RichBlockAudio) { v.Type = rb.Type })
+	case RichBlockTypeDocument:
+		return marshalVariant("RichBlock", rb.Type, rb.RichBlockDocument, func(v *RichBlockDocument) { v.Type = rb.Type })
 	case RichBlockTypePhoto:
 		return marshalVariant("RichBlock", rb.Type, rb.RichBlockPhoto, func(v *RichBlockPhoto) { v.Type = rb.Type })
 	case RichBlockTypeVideo:
@@ -158,6 +170,10 @@ func (rb *RichBlock) UnmarshalJSON(data []byte) error {
 		rb.Type = RichBlockTypeBlockQuotation
 		rb.RichBlockBlockQuotation = &RichBlockBlockQuotation{}
 		return json.Unmarshal(data, rb.RichBlockBlockQuotation)
+	case RichBlockTypeExpandableBlockQuotation:
+		rb.Type = RichBlockTypeExpandableBlockQuotation
+		rb.RichBlockExpandableBlockQuotation = &RichBlockExpandableBlockQuotation{}
+		return json.Unmarshal(data, rb.RichBlockExpandableBlockQuotation)
 	case RichBlockTypePullQuotation:
 		rb.Type = RichBlockTypePullQuotation
 		rb.RichBlockPullQuotation = &RichBlockPullQuotation{}
@@ -182,6 +198,10 @@ func (rb *RichBlock) UnmarshalJSON(data []byte) error {
 		rb.Type = RichBlockTypeMap
 		rb.RichBlockMap = &RichBlockMap{}
 		return json.Unmarshal(data, rb.RichBlockMap)
+	case RichBlockTypeButtons:
+		rb.Type = RichBlockTypeButtons
+		rb.RichBlockButtons = &RichBlockButtons{}
+		return json.Unmarshal(data, rb.RichBlockButtons)
 	case RichBlockTypeAnimation:
 		rb.Type = RichBlockTypeAnimation
 		rb.RichBlockAnimation = &RichBlockAnimation{}
@@ -190,6 +210,10 @@ func (rb *RichBlock) UnmarshalJSON(data []byte) error {
 		rb.Type = RichBlockTypeAudio
 		rb.RichBlockAudio = &RichBlockAudio{}
 		return json.Unmarshal(data, rb.RichBlockAudio)
+	case RichBlockTypeDocument:
+		rb.Type = RichBlockTypeDocument
+		rb.RichBlockDocument = &RichBlockDocument{}
+		return json.Unmarshal(data, rb.RichBlockDocument)
 	case RichBlockTypePhoto:
 		rb.Type = RichBlockTypePhoto
 		rb.RichBlockPhoto = &RichBlockPhoto{}
@@ -267,6 +291,13 @@ type RichBlockBlockQuotation struct {
 	Credit *RichText     `json:"credit,omitempty"`
 }
 
+// RichBlockExpandableBlockQuotation https://core.telegram.org/bots/api#richblockexpandableblockquotation
+type RichBlockExpandableBlockQuotation struct {
+	Type   RichBlockType `json:"type"`
+	Text   RichText      `json:"text"`
+	Credit *RichText     `json:"credit,omitempty"`
+}
+
 // RichBlockPullQuotation https://core.telegram.org/bots/api#richblockpullquotation
 type RichBlockPullQuotation struct {
 	Type   RichBlockType `json:"type"`
@@ -294,6 +325,7 @@ type RichBlockTable struct {
 	Cells      [][]RichBlockTableCell `json:"cells"`
 	IsBordered bool                   `json:"is_bordered,omitempty"`
 	IsStriped  bool                   `json:"is_striped,omitempty"`
+	IsCompact  bool                   `json:"is_compact,omitempty"`
 	Caption    *RichText              `json:"caption,omitempty"`
 }
 
@@ -315,6 +347,13 @@ type RichBlockMap struct {
 	Caption  *RichBlockCaption `json:"caption,omitempty"`
 }
 
+// RichBlockButtons https://core.telegram.org/bots/api#richblockbuttons
+type RichBlockButtons struct {
+	Type    RichBlockType       `json:"type"`
+	Buttons []RichMessageButton `json:"buttons"`
+	Align   string              `json:"align,omitempty"`
+}
+
 // RichBlockAnimation https://core.telegram.org/bots/api#richblockanimation
 type RichBlockAnimation struct {
 	Type       RichBlockType     `json:"type"`
@@ -328,6 +367,13 @@ type RichBlockAudio struct {
 	Type    RichBlockType     `json:"type"`
 	Audio   Audio             `json:"audio"`
 	Caption *RichBlockCaption `json:"caption,omitempty"`
+}
+
+// RichBlockDocument https://core.telegram.org/bots/api#richblockdocument
+type RichBlockDocument struct {
+	Type     RichBlockType     `json:"type"`
+	Document Document          `json:"document"`
+	Caption  *RichBlockCaption `json:"caption,omitempty"`
 }
 
 // RichBlockPhoto https://core.telegram.org/bots/api#richblockphoto

--- a/models/rich_block_test.go
+++ b/models/rich_block_test.go
@@ -115,3 +115,40 @@ func TestRichBlock_MarshalDoesNotMutate(t *testing.T) {
 		t.Fatalf("marshal mutated the caller's variant: Type = %q", variant.Type)
 	}
 }
+
+func TestRichBlock_ExpandableBlockQuotation(t *testing.T) {
+	rb := richBlockRoundTrip(t, `{"type":"expandable_blockquote","text":"quoted","credit":"author"}`)
+	if rb.Type != RichBlockTypeExpandableBlockQuotation {
+		t.Fatalf("wrong type %q", rb.Type)
+	}
+	if rb.RichBlockExpandableBlockQuotation == nil || rb.RichBlockExpandableBlockQuotation.Text.PlainText != "quoted" {
+		t.Fatal("expandable blockquote text not decoded")
+	}
+}
+
+func TestRichBlock_Buttons(t *testing.T) {
+	rb := richBlockRoundTrip(t, `{"type":"buttons","buttons":[{"text":"Go","style":"primary","callback_data":"go"},{"text":"Off","disabled":{}}],"align":"center"}`)
+	if rb.RichBlockButtons == nil || len(rb.RichBlockButtons.Buttons) != 2 {
+		t.Fatal("buttons not decoded")
+	}
+	if rb.RichBlockButtons.Buttons[0].CallbackData != "go" {
+		t.Fatal("callback_data not decoded")
+	}
+	if rb.RichBlockButtons.Buttons[1].Disabled == nil {
+		t.Fatal("disabled button not decoded")
+	}
+}
+
+func TestRichBlock_Document(t *testing.T) {
+	rb := richBlockRoundTrip(t, `{"type":"document","document":{"file_id":"f","file_unique_id":"u","file_name":"a.pdf"},"caption":{"text":"cap"}}`)
+	if rb.RichBlockDocument == nil || rb.RichBlockDocument.Document.FileID != "f" {
+		t.Fatal("document not decoded")
+	}
+}
+
+func TestRichBlock_TableIsCompact(t *testing.T) {
+	rb := richBlockRoundTrip(t, `{"type":"table","cells":[[{"align":"left","valign":"top"}]],"is_compact":true}`)
+	if rb.RichBlockTable == nil || !rb.RichBlockTable.IsCompact {
+		t.Fatal("is_compact not decoded")
+	}
+}

--- a/models/rich_message.go
+++ b/models/rich_message.go
@@ -24,7 +24,7 @@ type InputRichMessage struct {
 // InputRichMessageMedia https://core.telegram.org/bots/api#inputrichmessagemedia
 //
 // Media referenced from the markdown or html fields of an InputRichMessage via
-// tg://photo?id=, tg://video?id=, and tg://audio?id= links.
+// tg://photo?id=, tg://video?id=, tg://audio?id= and tg://document?id= links.
 type InputRichMessageMedia struct {
 	ID    string     `json:"id"`
 	Media InputMedia `json:"media"`
@@ -68,4 +68,22 @@ type RichBlockTableCell struct {
 	Rowspan  int       `json:"rowspan,omitempty"`
 	Align    string    `json:"align"`
 	Valign   string    `json:"valign"`
+}
+
+// RichMessageButton https://core.telegram.org/bots/api#richmessagebutton
+//
+// A button in a RichMessage. Exactly one of the fields other than Text and Style
+// must be set to specify the type of the button.
+type RichMessageButton struct {
+	Text                         RichText                     `json:"text"`
+	Style                        string                       `json:"style,omitempty"`
+	URL                          string                       `json:"url,omitempty"`
+	CallbackData                 string                       `json:"callback_data,omitempty"`
+	WebApp                       *WebAppInfo                  `json:"web_app,omitempty"`
+	LoginURL                     *LoginURL                    `json:"login_url,omitempty"`
+	SwitchInlineQuery            *string                      `json:"switch_inline_query,omitempty"`
+	SwitchInlineQueryCurrentChat *string                      `json:"switch_inline_query_current_chat,omitempty"`
+	SwitchInlineQueryChosenChat  *SwitchInlineQueryChosenChat `json:"switch_inline_query_chosen_chat,omitempty"`
+	CopyText                     *CopyTextButton              `json:"copy_text,omitempty"`
+	Disabled                     *DisabledButton              `json:"disabled,omitempty"`
 }

--- a/models/rich_text.go
+++ b/models/rich_text.go
@@ -31,6 +31,7 @@ const (
 	RichTextTypeHashtag                RichTextType = "hashtag"
 	RichTextTypeCashtag                RichTextType = "cashtag"
 	RichTextTypeBotCommand             RichTextType = "bot_command"
+	RichTextTypeButton                 RichTextType = "button"
 	RichTextTypeAnchor                 RichTextType = "anchor"
 	RichTextTypeAnchorLink             RichTextType = "anchor_link"
 	RichTextTypeReference              RichTextType = "reference"
@@ -70,6 +71,7 @@ type RichText struct {
 	RichTextHashtag                *RichTextHashtag
 	RichTextCashtag                *RichTextCashtag
 	RichTextBotCommand             *RichTextBotCommand
+	RichTextButton                 *RichTextButton
 	RichTextAnchor                 *RichTextAnchor
 	RichTextAnchorLink             *RichTextAnchorLink
 	RichTextReference              *RichTextReference
@@ -128,6 +130,8 @@ func (rt RichText) MarshalJSON() ([]byte, error) {
 		return marshalVariant("RichText", rt.Type, rt.RichTextCashtag, func(v *RichTextCashtag) { v.Type = rt.Type })
 	case RichTextTypeBotCommand:
 		return marshalVariant("RichText", rt.Type, rt.RichTextBotCommand, func(v *RichTextBotCommand) { v.Type = rt.Type })
+	case RichTextTypeButton:
+		return marshalVariant("RichText", rt.Type, rt.RichTextButton, func(v *RichTextButton) { v.Type = rt.Type })
 	case RichTextTypeAnchor:
 		return marshalVariant("RichText", rt.Type, rt.RichTextAnchor, func(v *RichTextAnchor) { v.Type = rt.Type })
 	case RichTextTypeAnchorLink:
@@ -252,6 +256,10 @@ func (rt *RichText) UnmarshalJSON(data []byte) error {
 		rt.Type = RichTextTypeBotCommand
 		rt.RichTextBotCommand = &RichTextBotCommand{}
 		return json.Unmarshal(trimmed, rt.RichTextBotCommand)
+	case RichTextTypeButton:
+		rt.Type = RichTextTypeButton
+		rt.RichTextButton = &RichTextButton{}
+		return json.Unmarshal(trimmed, rt.RichTextButton)
 	case RichTextTypeAnchor:
 		rt.Type = RichTextTypeAnchor
 		rt.RichTextAnchor = &RichTextAnchor{}
@@ -409,6 +417,12 @@ type RichTextBotCommand struct {
 	Type       RichTextType `json:"type"`
 	Text       RichText     `json:"text"`
 	BotCommand string       `json:"bot_command"`
+}
+
+// RichTextButton https://core.telegram.org/bots/api#richtextbutton
+type RichTextButton struct {
+	Type   RichTextType      `json:"type"`
+	Button RichMessageButton `json:"button"`
 }
 
 // RichTextAnchor https://core.telegram.org/bots/api#richtextanchor

--- a/models/rich_text_test.go
+++ b/models/rich_text_test.go
@@ -143,3 +143,13 @@ func TestRichText_MarshalDoesNotMutate(t *testing.T) {
 		t.Fatalf("marshal mutated the caller's variant: Type = %q", variant.Type)
 	}
 }
+
+func TestRichText_Button(t *testing.T) {
+	rt := richTextRoundTrip(t, `{"type":"button","button":{"text":"Open","url":"https://example.com"}}`)
+	if rt.Type != RichTextTypeButton {
+		t.Fatalf("wrong type %q", rt.Type)
+	}
+	if rt.RichTextButton == nil || rt.RichTextButton.Button.URL != "https://example.com" {
+		t.Fatal("button not decoded")
+	}
+}

--- a/models/update.go
+++ b/models/update.go
@@ -2,61 +2,63 @@ package models
 
 // Update https://core.telegram.org/bots/api#update
 type Update struct {
-	ID                      int64                        `json:"update_id"`
-	Message                 *Message                     `json:"message,omitempty"`
-	EditedMessage           *Message                     `json:"edited_message,omitempty"`
-	ChannelPost             *Message                     `json:"channel_post,omitempty"`
-	EditedChannelPost       *Message                     `json:"edited_channel_post,omitempty"`
-	BusinessConnection      *BusinessConnection          `json:"business_connection,omitempty"`
-	BusinessMessage         *Message                     `json:"business_message,omitempty"`
-	EditedBusinessMessage   *Message                     `json:"edited_business_message,omitempty"`
-	DeletedBusinessMessages *BusinessMessagesDeleted     `json:"deleted_business_messages,omitempty"`
-	MessageReaction         *MessageReactionUpdated      `json:"message_reaction,omitempty"`
-	MessageReactionCount    *MessageReactionCountUpdated `json:"message_reaction_count,omitempty"`
-	InlineQuery             *InlineQuery                 `json:"inline_query,omitempty"`
-	ChosenInlineResult      *ChosenInlineResult          `json:"chosen_inline_result,omitempty"`
-	CallbackQuery           *CallbackQuery               `json:"callback_query,omitempty"`
-	ShippingQuery           *ShippingQuery               `json:"shipping_query,omitempty"`
-	PreCheckoutQuery        *PreCheckoutQuery            `json:"pre_checkout_query,omitempty"`
-	PurchasedPaidMedia      *PaidMediaPurchased          `json:"purchased_paid_media,omitempty"`
-	Poll                    *Poll                        `json:"poll,omitempty"`
-	PollAnswer              *PollAnswer                  `json:"poll_answer,omitempty"`
-	ManagedBot              *ManagedBotUpdated           `json:"managed_bot,omitempty"`
-	GuestMessage            *Message                     `json:"guest_message,omitempty"`
-	MyChatMember            *ChatMemberUpdated           `json:"my_chat_member,omitempty"`
-	ChatMember              *ChatMemberUpdated           `json:"chat_member,omitempty"`
-	ChatJoinRequest         *ChatJoinRequest             `json:"chat_join_request,omitempty"`
-	ChatBoost               *ChatBoostUpdated            `json:"chat_boost,omitempty"`
-	RemovedChatBoost        *ChatBoostRemoved            `json:"removed_chat_boost,omitempty"`
-	Subscription            *BotSubscriptionUpdated      `json:"subscription,omitempty"`
+	ID                       int64                        `json:"update_id"`
+	Message                  *Message                     `json:"message,omitempty"`
+	EditedMessage            *Message                     `json:"edited_message,omitempty"`
+	ChannelPost              *Message                     `json:"channel_post,omitempty"`
+	EditedChannelPost        *Message                     `json:"edited_channel_post,omitempty"`
+	BusinessConnection       *BusinessConnection          `json:"business_connection,omitempty"`
+	BusinessMessage          *Message                     `json:"business_message,omitempty"`
+	EditedBusinessMessage    *Message                     `json:"edited_business_message,omitempty"`
+	DeletedBusinessMessages  *BusinessMessagesDeleted     `json:"deleted_business_messages,omitempty"`
+	MessageReaction          *MessageReactionUpdated      `json:"message_reaction,omitempty"`
+	MessageReactionCount     *MessageReactionCountUpdated `json:"message_reaction_count,omitempty"`
+	InlineQuery              *InlineQuery                 `json:"inline_query,omitempty"`
+	ChosenInlineResult       *ChosenInlineResult          `json:"chosen_inline_result,omitempty"`
+	CallbackQuery            *CallbackQuery               `json:"callback_query,omitempty"`
+	ShippingQuery            *ShippingQuery               `json:"shipping_query,omitempty"`
+	PreCheckoutQuery         *PreCheckoutQuery            `json:"pre_checkout_query,omitempty"`
+	PurchasedPaidMedia       *PaidMediaPurchased          `json:"purchased_paid_media,omitempty"`
+	Poll                     *Poll                        `json:"poll,omitempty"`
+	PollAnswer               *PollAnswer                  `json:"poll_answer,omitempty"`
+	ManagedBot               *ManagedBotUpdated           `json:"managed_bot,omitempty"`
+	GuestMessage             *Message                     `json:"guest_message,omitempty"`
+	MyChatMember             *ChatMemberUpdated           `json:"my_chat_member,omitempty"`
+	ChatMember               *ChatMemberUpdated           `json:"chat_member,omitempty"`
+	ChatJoinRequest          *ChatJoinRequest             `json:"chat_join_request,omitempty"`
+	ChatBoost                *ChatBoostUpdated            `json:"chat_boost,omitempty"`
+	RemovedChatBoost         *ChatBoostRemoved            `json:"removed_chat_boost,omitempty"`
+	Subscription             *BotSubscriptionUpdated      `json:"subscription,omitempty"`
+	StoppedMessageGeneration *MessageGenerationStopped    `json:"stopped_message_generation,omitempty"`
 }
 
 // allowed_updates https://core.telegram.org/bots/api#update
 const (
-	AllowedUpdateMessage                 string = "message"
-	AllowedUpdateEditedMessage           string = "edited_message"
-	AllowedUpdateChannelPost             string = "channel_post"
-	AllowedUpdateEditedChannelPost       string = "edited_channel_post"
-	AllowedUpdateBusinessConnection      string = "business_connection"
-	AllowedUpdateBusinessMessage         string = "business_message"
-	AllowedUpdateEditedBusinessMessage   string = "edited_business_message"
-	AllowedUpdateDeletedBusinessMessages string = "deleted_business_messages"
-	AllowedUpdateMessageReaction         string = "message_reaction"
-	AllowedUpdateMessageReactionCount    string = "message_reaction_count"
-	AllowedUpdateInlineQuery             string = "inline_query"
-	AllowedUpdateChosenInlineResult      string = "chosen_inline_result"
-	AllowedUpdateCallbackQuery           string = "callback_query"
-	AllowedUpdateShippingQuery           string = "shipping_query"
-	AllowedUpdatePreCheckoutQuery        string = "pre_checkout_query"
-	AllowedUpdatePurchasedPaidMedia      string = "purchased_paid_media"
-	AllowedUpdatePoll                    string = "poll"
-	AllowedUpdatePollAnswer              string = "poll_answer"
-	AllowedUpdateMyChatMember            string = "my_chat_member"
-	AllowedUpdateChatMember              string = "chat_member"
-	AllowedUpdateChatJoinRequest         string = "chat_join_request"
-	AllowedUpdateChatBoost               string = "chat_boost"
-	AllowedUpdateRemovedChatBoost        string = "removed_chat_boost"
-	AllowedUpdateManagedBot              string = "managed_bot"
-	AllowedUpdateGuestMessage            string = "guest_message"
-	AllowedUpdateSubscription            string = "subscription"
+	AllowedUpdateMessage                  string = "message"
+	AllowedUpdateEditedMessage            string = "edited_message"
+	AllowedUpdateChannelPost              string = "channel_post"
+	AllowedUpdateEditedChannelPost        string = "edited_channel_post"
+	AllowedUpdateBusinessConnection       string = "business_connection"
+	AllowedUpdateBusinessMessage          string = "business_message"
+	AllowedUpdateEditedBusinessMessage    string = "edited_business_message"
+	AllowedUpdateDeletedBusinessMessages  string = "deleted_business_messages"
+	AllowedUpdateMessageReaction          string = "message_reaction"
+	AllowedUpdateMessageReactionCount     string = "message_reaction_count"
+	AllowedUpdateInlineQuery              string = "inline_query"
+	AllowedUpdateChosenInlineResult       string = "chosen_inline_result"
+	AllowedUpdateCallbackQuery            string = "callback_query"
+	AllowedUpdateShippingQuery            string = "shipping_query"
+	AllowedUpdatePreCheckoutQuery         string = "pre_checkout_query"
+	AllowedUpdatePurchasedPaidMedia       string = "purchased_paid_media"
+	AllowedUpdatePoll                     string = "poll"
+	AllowedUpdatePollAnswer               string = "poll_answer"
+	AllowedUpdateMyChatMember             string = "my_chat_member"
+	AllowedUpdateChatMember               string = "chat_member"
+	AllowedUpdateChatJoinRequest          string = "chat_join_request"
+	AllowedUpdateChatBoost                string = "chat_boost"
+	AllowedUpdateRemovedChatBoost         string = "removed_chat_boost"
+	AllowedUpdateManagedBot               string = "managed_bot"
+	AllowedUpdateGuestMessage             string = "guest_message"
+	AllowedUpdateSubscription             string = "subscription"
+	AllowedUpdateStoppedMessageGeneration string = "stopped_message_generation"
 )


### PR DESCRIPTION
Adds full Bot API 10.3 support (August 24, 2026), following the existing RichBlock / RichText tagged-union (`marshalVariant`) and rawRequest patterns.

## Rich Messages

- New `RichMessageButton` and the `RichTextButton` variant of the `RichText` union (`type: "button"`).
- New block types in the `RichBlock` and `InputRichBlock` unions:
  `RichBlockButtons` / `InputRichBlockButtons`,
  `RichBlockExpandableBlockQuotation` / `InputRichBlockExpandableBlockQuotation`,
  `RichBlockDocument` / `InputRichBlockDocument`, with the matching
  `RichBlockType*` constants.
- `is_compact` on `RichBlockTable` and `InputRichBlockTable`.
- `tg://document?id=` links documented for `InputRichMessageMedia`.

## Ephemeral Messages

- New `models.EphemeralMessageParameters` (`receiver_user_id`, `callback_query_id`, `replace_callback_query_message`).
- The 13 send methods (`sendMessage`, `sendAnimation`, `sendAudio`, `sendDocument`, `sendLivePhoto`, `sendPhoto`, `sendSticker`, `sendVideo`, `sendVideoNote`, `sendVoice`, `sendContact`, `sendLocation`, `sendVenue`) now take `ephemeral_message_parameters` instead of `receiver_user_id` + `callback_query_id`; the same parameter is added to `sendRichMessage`.
- `rich_message` on `editEphemeralMessageText` (`text` is now optional, as it is required only when `rich_message` is not given).
- `show_caption_above_media` on `editEphemeralMessageCaption`.
- Upload of new files in `editEphemeralMessageMedia`: the existing `InputMedia` form handling already attaches `attach://` files; covered by a test that asserts the multipart file part.
- `can_send_welcome_messages` on `ChatAdministratorRights`, `ChatMemberAdministrator` and `promoteChatMember`.

## Reply markup

- New `DisabledButton` with the `disabled` field on `InlineKeyboardButton`.
- `force_reply` on `InlineKeyboardMarkup` and `ReplyKeyboardMarkup`.

## General

- `can_stop` and `keep_on_stop` on `sendMessageDraft` and `sendRichMessageDraft`.
- New `MessageGenerationStopped` with the `stopped_message_generation` field on `Update` and the `AllowedUpdateStoppedMessageGeneration` constant.
- New `CommunityChatJoined` with `community_chat_joined` on `Message`.
- `text`, `entities` and `is_private` on `UniqueGiftInfo`.
- README and CHANGELOG bumped to 10.3 (v1.24.0).

## Breaking change

`ReceiverUserID` and `CallbackQueryID` are removed from the send method params (`SendMessageParams`, `SendPhotoParams`, ...). Bot API 10.3 replaced them with `EphemeralMessageParameters`:

```go
// before
b.SendMessage(ctx, &bot.SendMessageParams{ChatID: id, Text: "hi", ReceiverUserID: uid, CallbackQueryID: cq})

// after
b.SendMessage(ctx, &bot.SendMessageParams{
      ChatID: id,
      Text:   "hi",
      EphemeralMessageParameters: &models.EphemeralMessageParameters{ReceiverUserID: uid, CallbackQueryID: cq},
})

AnswerCallbackQueryParams.CallbackQueryID is unchanged.