### PR TITLE
fix: return error for attach:// with a nil reader

### DIFF
--- a/build_request_form.go
+++ b/build_request_form.go
@@ -147,6 +147,9 @@ func addFormFieldInputFileUpload(form *multipart.Writer, fieldName string, value
 func addFormFieldInputMediaItem(form *multipart.Writer, value inputMedia) ([]byte, error) {
 	if strings.HasPrefix(value.GetMedia(), "attach://") {
 		filename := strings.TrimPrefix(value.GetMedia(), "attach://")
+		if readerIsNil(value.Attachment()) {
+			return nil, fmt.Errorf("nil attachment for attach://%s", filename)
+		}
 		mediaAttachmentField, errCreateMediaAttachmentField := form.CreateFormFile(filename, filename)
 		if errCreateMediaAttachmentField != nil {
 			return nil, errCreateMediaAttachmentField
@@ -240,6 +243,9 @@ func addFormFieldInputStickerSlice(form *multipart.Writer, fieldName string, val
 	for _, sticker := range value {
 		if strings.HasPrefix(sticker.Sticker, "attach://") {
 			filename := strings.TrimPrefix(sticker.Sticker, "attach://")
+			if readerIsNil(sticker.StickerAttachment) {
+				return fmt.Errorf("nil StickerAttachment for attach://%s", filename)
+			}
 			attachmentField, errCreateAttachmentField := form.CreateFormFile(filename, filename)
 			if errCreateAttachmentField != nil {
 				return errCreateAttachmentField

--- a/build_request_form_test.go
+++ b/build_request_form_test.go
@@ -169,3 +169,30 @@ Content-Disposition: form-data; name="input_sticker_slice"
 	assertEqualInt(t, fieldsCount, 7)
 	assertFormData(t, buf.String(), expect)
 }
+
+func Test_addFormFieldInputMedia_nilAttachment(t *testing.T) {
+	form := multipart.NewWriter(bytes.NewBuffer(nil))
+	err := addFormFieldInputMedia(form, "media", &models.InputMediaPhoto{
+		Media: "attach://photo.png",
+	})
+	if err == nil {
+		t.Fatal("expected error for attach:// with nil MediaAttachment")
+	}
+	if !strings.Contains(err.Error(), "nil attachment") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func Test_addFormFieldInputStickerSlice_nilAttachment(t *testing.T) {
+	form := multipart.NewWriter(bytes.NewBuffer(nil))
+	err := addFormFieldInputStickerSlice(form, "stickers", []models.InputSticker{{
+		Sticker: "attach://sticker.png",
+		Format:  "static",
+	}})
+	if err == nil {
+		t.Fatal("expected error for attach:// with nil StickerAttachment")
+	}
+	if !strings.Contains(err.Error(), "nil StickerAttachment") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
`attach://` with a nil reader panicked in `addFormFieldInputMediaItem` and `addFormFieldInputStickerSlice`. `InputFileUpload` and `InputMediaLivePhoto` already return an error via `readerIsNil`; these two paths did `io.Copy` instead.

`buildRequestForm` runs in the `rawRequest` goroutine with no recover, so that panic took the process down.

Use the same `readerIsNil` check.

Fixes #296

## Test plan
- [x] `go test -count=1 .`
- [x] `go test -count=1 -run Test_addFormFieldInputMedia_nilAttachment .`
- [x] `go test -count=1 -run Test_addFormFieldInputStickerSlice_nilAttachment .`

Made with [Cursor](https://cursor.com)