### PR TITLE
fix: upload attachments nested in rich messages and InputMedia thumbnails (#298)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@
   reader without checking it, and since the form is built in a goroutine with no
   recover, a missing `MediaAttachment` or `StickerAttachment` took the process
   down instead of failing the call (#296).
+- Fix: attachments nested in a rich message are uploaded. `buildRequestForm` had
+  no case for `InputRichMessage`, so the field fell through to a plain
+  `json.Marshal` and the `attach://` references in `InputRichMessage.Media` and
+  in the media `InputRichBlock*` blocks were serialized without their file parts,
+  leaving Telegram nothing to resolve them against (#298).
 - Fix: `can_post_stories`, `can_edit_stories` and `can_delete_stories` are no
   longer marked `omitempty` on `ChatAdministratorRights` and
   `ChatMemberAdministrator`. They are required fields in the Bot API, so they

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,13 +42,25 @@
   `attach://<filename>` and uploaded under that name. `InputFileUpload.MarshalJSON`
   emits the same reference everywhere; at the top level of a request the field is
   still sent as its own form part, so that path is unchanged.
-- Fix: two file parts sharing a name are rejected with an error instead of both
-  being written. The name of a part is what an `attach://` reference resolves
-  against, so a duplicate — most easily two thumbnails with the same `Filename` —
-  silently made Telegram resolve both references to the first file.
-- Fix: a typed nil `InputFile` thumbnail or a typed nil `InputMedia` in
-  `InputRichMessage.Media` no longer panics while the form is built. Both are
-  skipped, and the encoder writes them as `null`.
+- Fix: two different files sharing a part name are rejected with an error instead
+  of both being written. The name of a part is what an `attach://` reference
+  resolves against, so a duplicate — most easily two thumbnails with the same
+  `Filename` — silently made Telegram resolve both references to the first file.
+  One file referenced from several entries under a single name still works: the
+  part is written once and reused. A file part and a form field of the same name
+  are the same ambiguity and are rejected too.
+- Fix: a typed nil `InputFile` or `InputMedia` no longer panics while the form is
+  built. A typed nil in a top level `InputFile` field, in `InputMedia` /
+  `InputPaidMedia` (single or slice) or in `InputRichMessage.Media` is reported as
+  an error, and a typed nil thumbnail nested in an `InputMedia` is omitted from
+  the encoded media instead of being sent as a `null` the Bot API rejects.
+- Fix: a nested `InputFileUpload` with an empty `Filename` is rejected. `Filename`
+  is the `attach://` reference and the part name, so an empty one produced
+  `"thumbnail":"attach://"` and an opaque `Bad Request` from Telegram.
+- Fix: `InputFileUpload.MarshalJSON` and `InputFileString.MarshalJSON` escape
+  their value instead of concatenating it into a JSON string. A `Filename` or a
+  `file_id` containing a quote or a backslash produced invalid JSON, failing the
+  request after the file parts had already been streamed.
 - Fix: `can_post_stories`, `can_edit_stories` and `can_delete_stories` are no
   longer marked `omitempty` on `ChatAdministratorRights` and
   `ChatMemberAdministrator`. They are required fields in the Bot API, so they

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,14 @@
   `json.Marshal` and the `attach://` references in `InputRichMessage.Media` and
   in the media `InputRichBlock*` blocks were serialized without their file parts,
   leaving Telegram nothing to resolve them against (#298).
+- Fix: the thumbnail of an `InputMedia` is uploaded. `InputFileUpload` nested in
+  an `InputMediaVideo`, `InputMediaAnimation`, `InputMediaAudio`,
+  `InputMediaDocument` or `InputPaidMediaVideo` was encoded as `"@<filename>"`,
+  which is not a Bot API reference, and no file part was written, so the
+  thumbnail was silently dropped by Telegram. It is now marshalled as
+  `attach://<filename>` and uploaded under that name. `InputFileUpload.MarshalJSON`
+  emits the same reference everywhere; at the top level of a request the field is
+  still sent as its own form part, so that path is unchanged.
 - Fix: `can_post_stories`, `can_edit_stories` and `can_delete_stories` are no
   longer marked `omitempty` on `ChatAdministratorRights` and
   `ChatMemberAdministrator`. They are required fields in the Bot API, so they

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,13 @@
   `attach://<filename>` and uploaded under that name. `InputFileUpload.MarshalJSON`
   emits the same reference everywhere; at the top level of a request the field is
   still sent as its own form part, so that path is unchanged.
+- Fix: two file parts sharing a name are rejected with an error instead of both
+  being written. The name of a part is what an `attach://` reference resolves
+  against, so a duplicate — most easily two thumbnails with the same `Filename` —
+  silently made Telegram resolve both references to the first file.
+- Fix: a typed nil `InputFile` thumbnail or a typed nil `InputMedia` in
+  `InputRichMessage.Media` no longer panics while the form is built. Both are
+  skipped, and the encoder writes them as `null`.
 - Fix: `can_post_stories`, `can_edit_stories` and `can_delete_stories` are no
   longer marked `omitempty` on `ChatAdministratorRights` and
   `ChatMemberAdministrator`. They are required fields in the Bot API, so they

--- a/README.md
+++ b/README.md
@@ -321,6 +321,20 @@ bot.SendMediaGroup(ctx, params)
 
 [Demo in examples](examples/send_media_group/main.go)
 
+A thumbnail is always a new upload, never a `file_id` or an URL. Pass an
+`InputFileUpload`; it is sent as a separate part and referenced by `attach://` with
+the `Filename` as the part name.
+
+```go
+thumbContent, _ := os.ReadFile("/path/to/thumb.jpg")
+
+media := &models.InputMediaVideo{
+	Media:           "attach://video.mp4",
+	MediaAttachment: bytes.NewReader(videoContent),
+	Thumbnail:       &models.InputFileUpload{Filename: "thumb.jpg", Data: bytes.NewReader(thumbContent)},
+}
+```
+
 ## InputSticker
 
 For `CreateNewStickerSet` method you can send sticker by file path or file contents.

--- a/README.md
+++ b/README.md
@@ -326,8 +326,11 @@ Telegram does not accept a reused file as a thumbnail, so a thumbnail is normall
 `Filename` as the part name. An `InputFileString` is passed through unchanged, so a
 `file_id` or an URL reaches the API as written.
 
-Part names must be unique within one request: two attachments sharing a name are
-rejected with an error, since Telegram would resolve both references to the first file.
+A part name identifies one file within a request. Referencing the same file from
+several entries under one name is fine — the part is written once and every reference
+resolves to it — but two different files sharing a name are rejected with an error,
+since Telegram would resolve both references to the first of them. A file part and a
+form field cannot share a name either.
 
 ```go
 thumbContent, _ := os.ReadFile("/path/to/thumb.jpg")

--- a/README.md
+++ b/README.md
@@ -321,9 +321,13 @@ bot.SendMediaGroup(ctx, params)
 
 [Demo in examples](examples/send_media_group/main.go)
 
-A thumbnail is always a new upload, never a `file_id` or an URL. Pass an
-`InputFileUpload`; it is sent as a separate part and referenced by `attach://` with
-the `Filename` as the part name.
+Telegram does not accept a reused file as a thumbnail, so a thumbnail is normally an
+`InputFileUpload`: it is sent as a separate part and referenced by `attach://`, with
+`Filename` as the part name. An `InputFileString` is passed through unchanged, so a
+`file_id` or an URL reaches the API as written.
+
+Part names must be unique within one request: two attachments sharing a name are
+rejected with an error, since Telegram would resolve both references to the first file.
 
 ```go
 thumbContent, _ := os.ReadFile("/path/to/thumb.jpg")

--- a/build_request_form.go
+++ b/build_request_form.go
@@ -38,24 +38,67 @@ type formWriter interface {
 	CreateFormFile(fieldName, filename string) (io.Writer, error)
 }
 
-// requestForm rejects two file parts sharing a name. The name of a part is what an
-// attach:// reference resolves against, so a duplicate silently makes Telegram resolve
-// both references to the first file.
+// requestForm tracks the names of the parts written to one request. A part name is
+// what an attach:// reference resolves against, so two different files under one name
+// are ambiguous and rejected, while one file referenced twice reuses the part already
+// written. A file part and a form field sharing a name are the same ambiguity.
 type requestForm struct {
-	formWriter
-	fileNames map[string]struct{}
+	w          formWriter
+	fileParts  map[string]io.Reader
+	fieldNames map[string]struct{}
 }
 
 func newRequestForm(w formWriter) *requestForm {
-	return &requestForm{formWriter: w, fileNames: map[string]struct{}{}}
+	return &requestForm{
+		w:          w,
+		fileParts:  map[string]io.Reader{},
+		fieldNames: map[string]struct{}{},
+	}
 }
 
-func (f *requestForm) CreateFormFile(fieldName, filename string) (io.Writer, error) {
-	if _, ok := f.fileNames[fieldName]; ok {
-		return nil, fmt.Errorf("duplicate form part name %q", fieldName)
+// hasFilePart reports whether a file part of that name is written, i.e. an attach://
+// reference to it already resolves and needs no attachment of its own.
+func (f *requestForm) hasFilePart(partName string) bool {
+	_, ok := f.fileParts[partName]
+	return ok
+}
+
+// addFilePart writes data as the file part partName. Repeating a name with the same
+// reader, or with none, references the file already uploaded under it.
+func (f *requestForm) addFilePart(partName, filename string, data io.Reader) error {
+	if written, ok := f.fileParts[partName]; ok {
+		if readerIsNil(data) || sameReader(written, data) {
+			return nil
+		}
+		return fmt.Errorf("duplicate form part name %q", partName)
 	}
-	f.fileNames[fieldName] = struct{}{}
-	return f.formWriter.CreateFormFile(fieldName, filename)
+	if _, ok := f.fieldNames[partName]; ok {
+		return fmt.Errorf("duplicate form part name %q", partName)
+	}
+	w, errCreatePart := f.w.CreateFormFile(partName, filename)
+	if errCreatePart != nil {
+		return errCreatePart
+	}
+	f.fileParts[partName] = data
+	_, errCopy := io.Copy(w, data)
+	return errCopy
+}
+
+// addFieldPart writes value as the form field fieldName.
+func (f *requestForm) addFieldPart(fieldName string, value io.Reader) error {
+	if _, ok := f.fieldNames[fieldName]; ok {
+		return fmt.Errorf("duplicate form part name %q", fieldName)
+	}
+	if _, ok := f.fileParts[fieldName]; ok {
+		return fmt.Errorf("duplicate form part name %q", fieldName)
+	}
+	w, errCreateField := f.w.CreateFormField(fieldName)
+	if errCreateField != nil {
+		return errCreateField
+	}
+	f.fieldNames[fieldName] = struct{}{}
+	_, errCopy := io.Copy(w, value)
+	return errCopy
 }
 
 // buildRequestForm builds form-data for request
@@ -176,19 +219,27 @@ func isNilValue(value any) bool {
 	}
 }
 
-func addFormFieldInputFileUpload(form formWriter, fieldName string, value *models.InputFileUpload) error {
+// sameReader reports whether two attachments are one reader, i.e. one file referenced
+// twice rather than two files claiming a single part name.
+func sameReader(a, b io.Reader) bool {
+	ta := reflect.TypeOf(a)
+	if ta == nil || ta != reflect.TypeOf(b) || !ta.Comparable() {
+		return false
+	}
+	return a == b
+}
+
+func addFormFieldInputFileUpload(form *requestForm, fieldName string, value *models.InputFileUpload) error {
+	if isNilValue(value) {
+		return fmt.Errorf("nil value for field %s", fieldName)
+	}
 	if readerIsNil(value.Data) {
 		return fmt.Errorf("nil data for field %s", fieldName)
 	}
-	w, errCreateField := form.CreateFormFile(fieldName, value.Filename)
-	if errCreateField != nil {
-		return errCreateField
-	}
-	_, errCopy := io.Copy(w, value.Data)
-	return errCopy
+	return form.addFilePart(fieldName, value.Filename, value.Data)
 }
 
-func addFormFieldInputMediaItem(form formWriter, value inputMedia) ([]byte, error) {
+func addFormFieldInputMediaItem(form *requestForm, value inputMedia) ([]byte, error) {
 	if err := addInputMediaAttachment(form, value); err != nil {
 		return nil, err
 	}
@@ -196,19 +247,14 @@ func addFormFieldInputMediaItem(form formWriter, value inputMedia) ([]byte, erro
 }
 
 // addInputMediaAttachment adds the attach:// upload parts referenced by a media item, if any.
-func addInputMediaAttachment(form formWriter, value inputMedia) error {
+func addInputMediaAttachment(form *requestForm, value inputMedia) error {
 	if strings.HasPrefix(value.GetMedia(), "attach://") {
 		filename := strings.TrimPrefix(value.GetMedia(), "attach://")
-		if readerIsNil(value.Attachment()) {
+		if !form.hasFilePart(filename) && readerIsNil(value.Attachment()) {
 			return fmt.Errorf("nil attachment for attach://%s", filename)
 		}
-		mediaAttachmentField, errCreateMediaAttachmentField := form.CreateFormFile(filename, filename)
-		if errCreateMediaAttachmentField != nil {
-			return errCreateMediaAttachmentField
-		}
-		_, errCopy := io.Copy(mediaAttachmentField, value.Attachment())
-		if errCopy != nil {
-			return errCopy
+		if err := form.addFilePart(filename, filename, value.Attachment()); err != nil {
+			return err
 		}
 	}
 	if thumbnailed, ok := value.(mediaThumbnail); ok {
@@ -218,14 +264,10 @@ func addInputMediaAttachment(form formWriter, value inputMedia) error {
 	}
 	if live, ok := value.(*models.InputMediaLivePhoto); ok && strings.HasPrefix(live.Photo, "attach://") {
 		filename := strings.TrimPrefix(live.Photo, "attach://")
-		if readerIsNil(live.PhotoAttachment) {
+		if !form.hasFilePart(filename) && readerIsNil(live.PhotoAttachment) {
 			return fmt.Errorf("nil PhotoAttachment for attach://%s", filename)
 		}
-		photoField, errCreate := form.CreateFormFile(filename, filename)
-		if errCreate != nil {
-			return errCreate
-		}
-		if _, err := io.Copy(photoField, live.PhotoAttachment); err != nil {
+		if err := form.addFilePart(filename, filename, live.PhotoAttachment); err != nil {
 			return err
 		}
 	}
@@ -234,53 +276,49 @@ func addInputMediaAttachment(form formWriter, value inputMedia) error {
 
 // addInputFileAttachment uploads a nested InputFile, which is marshalled as an
 // attach:// reference instead of becoming a form field of its own. Anything but an
-// upload (a file_id or an URL) carries no content and is left to the encoder.
-func addInputFileAttachment(form formWriter, value models.InputFile) error {
+// upload (a file_id or an URL) carries no content and is left to the encoder, and so
+// is a typed nil, which the encoder omits.
+func addInputFileAttachment(form *requestForm, value models.InputFile) error {
 	upload, ok := value.(*models.InputFileUpload)
 	if !ok || upload == nil {
 		return nil
 	}
-	if readerIsNil(upload.Data) {
+	if upload.Filename == "" {
+		return fmt.Errorf("empty filename for nested upload, it is the attach:// reference")
+	}
+	if !form.hasFilePart(upload.Filename) && readerIsNil(upload.Data) {
 		return fmt.Errorf("nil data for attach://%s", upload.Filename)
 	}
-	w, errCreateField := form.CreateFormFile(upload.Filename, upload.Filename)
-	if errCreateField != nil {
-		return errCreateField
-	}
-	_, errCopy := io.Copy(w, upload.Data)
-	return errCopy
+	return form.addFilePart(upload.Filename, upload.Filename, upload.Data)
 }
 
-func addFormFieldCustomMarshal(form formWriter, fieldName string, value customMarshal) error {
+func addFormFieldCustomMarshal(form *requestForm, fieldName string, value customMarshal) error {
 	line, errEncode := value.MarshalCustom()
 	if errEncode != nil {
 		return errEncode
 	}
-	w, errCreateField := form.CreateFormField(fieldName)
-	if errCreateField != nil {
-		return errCreateField
-	}
-	_, errCopy := io.Copy(w, bytes.NewReader(line))
-	return errCopy
+	return form.addFieldPart(fieldName, bytes.NewReader(line))
 }
 
-func addFormFieldInputMedia(form formWriter, fieldName string, value inputMedia) error {
+func addFormFieldInputMedia(form *requestForm, fieldName string, value inputMedia) error {
+	if isNilValue(value) {
+		return fmt.Errorf("nil value for field %s", fieldName)
+	}
+
 	line, err := addFormFieldInputMediaItem(form, value)
 	if err != nil {
 		return err
 	}
 
-	w, errCreateField := form.CreateFormField(fieldName)
-	if errCreateField != nil {
-		return errCreateField
-	}
-	_, errCopy := io.Copy(w, bytes.NewReader(line))
-	return errCopy
+	return form.addFieldPart(fieldName, bytes.NewReader(line))
 }
 
-func addFormFieldInputMediaSlice(form formWriter, fieldName string, value []inputMedia) error {
+func addFormFieldInputMediaSlice(form *requestForm, fieldName string, value []inputMedia) error {
 	var lines []string
-	for _, media := range value {
+	for i, media := range value {
+		if isNilValue(media) {
+			return fmt.Errorf("nil value for field %s at index %d", fieldName, i)
+		}
 		line, err := addFormFieldInputMediaItem(form, media)
 		if err != nil {
 			return err
@@ -288,23 +326,18 @@ func addFormFieldInputMediaSlice(form formWriter, fieldName string, value []inpu
 		lines = append(lines, string(line))
 	}
 
-	w, errCreateField := form.CreateFormField(fieldName)
-	if errCreateField != nil {
-		return errCreateField
-	}
-	_, errCopy := io.Copy(w, strings.NewReader("["+strings.Join(lines, ",")+"]"))
-	return errCopy
+	return form.addFieldPart(fieldName, strings.NewReader("["+strings.Join(lines, ",")+"]"))
 }
 
 // addFormFieldInputRichMessage adds the attach:// uploads referenced by a rich message
 // before encoding it, so that nested media is uploaded like top level InputMedia is.
-func addFormFieldInputRichMessage(form formWriter, fieldName string, value *models.InputRichMessage) error {
+func addFormFieldInputRichMessage(form *requestForm, fieldName string, value *models.InputRichMessage) error {
 	if err := addInputRichBlockSliceAttachments(form, value.Blocks); err != nil {
 		return err
 	}
-	for _, media := range value.Media {
+	for i, media := range value.Media {
 		if isNilValue(media.Media) {
-			continue
+			return fmt.Errorf("nil media for field %s at index %d", fieldName, i)
 		}
 		if err := addInputMediaAttachment(form, media.Media); err != nil {
 			return err
@@ -313,7 +346,7 @@ func addFormFieldInputRichMessage(form formWriter, fieldName string, value *mode
 	return addFormFieldDefault(form, fieldName, value)
 }
 
-func addInputRichBlockSliceAttachments(form formWriter, blocks []models.InputRichBlock) error {
+func addInputRichBlockSliceAttachments(form *requestForm, blocks []models.InputRichBlock) error {
 	for _, block := range blocks {
 		if err := addInputRichBlockAttachments(form, block); err != nil {
 			return err
@@ -324,7 +357,7 @@ func addInputRichBlockSliceAttachments(form formWriter, blocks []models.InputRic
 
 // addInputRichBlockAttachments walks a single block: media blocks upload their attachment,
 // container blocks recurse into their nested blocks.
-func addInputRichBlockAttachments(form formWriter, block models.InputRichBlock) error {
+func addInputRichBlockAttachments(form *requestForm, block models.InputRichBlock) error {
 	switch block.Type {
 	case models.RichBlockTypeAnimation:
 		if block.InputRichBlockAnimation != nil {
@@ -378,7 +411,7 @@ func addInputRichBlockAttachments(form formWriter, block models.InputRichBlock) 
 	return nil
 }
 
-func addFormFieldInlineQueryResultSlice(form formWriter, fieldName string, value []models.InlineQueryResult) error {
+func addFormFieldInlineQueryResultSlice(form *requestForm, fieldName string, value []models.InlineQueryResult) error {
 	var lines []string
 	for _, media := range value {
 		line, errEncode := media.MarshalCustom()
@@ -388,29 +421,19 @@ func addFormFieldInlineQueryResultSlice(form formWriter, fieldName string, value
 		lines = append(lines, string(line))
 	}
 
-	w, errCreateField := form.CreateFormField(fieldName)
-	if errCreateField != nil {
-		return errCreateField
-	}
-	_, errCopy := io.Copy(w, strings.NewReader("["+strings.Join(lines, ",")+"]"))
-	return errCopy
+	return form.addFieldPart(fieldName, strings.NewReader("["+strings.Join(lines, ",")+"]"))
 }
 
-func addFormFieldInputStickerSlice(form formWriter, fieldName string, value []models.InputSticker) error {
+func addFormFieldInputStickerSlice(form *requestForm, fieldName string, value []models.InputSticker) error {
 	var lines []string
 	for _, sticker := range value {
 		if strings.HasPrefix(sticker.Sticker, "attach://") {
 			filename := strings.TrimPrefix(sticker.Sticker, "attach://")
-			if readerIsNil(sticker.StickerAttachment) {
+			if !form.hasFilePart(filename) && readerIsNil(sticker.StickerAttachment) {
 				return fmt.Errorf("nil StickerAttachment for attach://%s", filename)
 			}
-			attachmentField, errCreateAttachmentField := form.CreateFormFile(filename, filename)
-			if errCreateAttachmentField != nil {
-				return errCreateAttachmentField
-			}
-			_, errCopy := io.Copy(attachmentField, sticker.StickerAttachment)
-			if errCopy != nil {
-				return errCopy
+			if err := form.addFilePart(filename, filename, sticker.StickerAttachment); err != nil {
+				return err
 			}
 		}
 		line, errEncode := json.Marshal(sticker)
@@ -420,33 +443,18 @@ func addFormFieldInputStickerSlice(form formWriter, fieldName string, value []mo
 		lines = append(lines, string(line))
 	}
 
-	w, errCreateField := form.CreateFormField(fieldName)
-	if errCreateField != nil {
-		return errCreateField
-	}
-	_, errCopy := io.Copy(w, strings.NewReader("["+strings.Join(lines, ",")+"]"))
-	return errCopy
+	return form.addFieldPart(fieldName, strings.NewReader("["+strings.Join(lines, ",")+"]"))
 }
 
-func addFormFieldDefault(form formWriter, fieldName string, value any) error {
+func addFormFieldDefault(form *requestForm, fieldName string, value any) error {
 	d, errMarshal := json.Marshal(value)
 	if errMarshal != nil {
 		return errMarshal
 	}
 	d = bytes.Trim(d, "\"") // for strings values
-	w, errCreateField := form.CreateFormField(fieldName)
-	if errCreateField != nil {
-		return errCreateField
-	}
-	_, errCopy := io.Copy(w, bytes.NewReader(d))
-	return errCopy
+	return form.addFieldPart(fieldName, bytes.NewReader(d))
 }
 
-func addFormFieldString(form formWriter, fieldName string, value string) error {
-	w, errCreateField := form.CreateFormField(fieldName)
-	if errCreateField != nil {
-		return errCreateField
-	}
-	_, errCopy := io.Copy(w, strings.NewReader(value))
-	return errCopy
+func addFormFieldString(form *requestForm, fieldName string, value string) error {
+	return form.addFieldPart(fieldName, strings.NewReader(value))
 }

--- a/build_request_form.go
+++ b/build_request_form.go
@@ -106,6 +106,10 @@ func buildRequestForm(form *multipart.Writer, params any) (int, error) {
 			err = addFormFieldInlineQueryResultSlice(form, fieldName, vv)
 		case []models.InputSticker:
 			err = addFormFieldInputStickerSlice(form, fieldName, vv)
+		case models.InputRichMessage:
+			err = addFormFieldInputRichMessage(form, fieldName, &vv)
+		case *models.InputRichMessage:
+			err = addFormFieldInputRichMessage(form, fieldName, vv)
 		default:
 			err = addFormFieldDefault(form, fieldName, v.Field(i).Interface())
 		}
@@ -145,34 +149,42 @@ func addFormFieldInputFileUpload(form *multipart.Writer, fieldName string, value
 }
 
 func addFormFieldInputMediaItem(form *multipart.Writer, value inputMedia) ([]byte, error) {
+	if err := addInputMediaAttachment(form, value); err != nil {
+		return nil, err
+	}
+	return value.MarshalInputMedia()
+}
+
+// addInputMediaAttachment adds the attach:// upload parts referenced by a media item, if any.
+func addInputMediaAttachment(form *multipart.Writer, value inputMedia) error {
 	if strings.HasPrefix(value.GetMedia(), "attach://") {
 		filename := strings.TrimPrefix(value.GetMedia(), "attach://")
 		if readerIsNil(value.Attachment()) {
-			return nil, fmt.Errorf("nil attachment for attach://%s", filename)
+			return fmt.Errorf("nil attachment for attach://%s", filename)
 		}
 		mediaAttachmentField, errCreateMediaAttachmentField := form.CreateFormFile(filename, filename)
 		if errCreateMediaAttachmentField != nil {
-			return nil, errCreateMediaAttachmentField
+			return errCreateMediaAttachmentField
 		}
 		_, errCopy := io.Copy(mediaAttachmentField, value.Attachment())
 		if errCopy != nil {
-			return nil, errCopy
+			return errCopy
 		}
 	}
 	if live, ok := value.(*models.InputMediaLivePhoto); ok && strings.HasPrefix(live.Photo, "attach://") {
 		filename := strings.TrimPrefix(live.Photo, "attach://")
 		if readerIsNil(live.PhotoAttachment) {
-			return nil, fmt.Errorf("nil PhotoAttachment for attach://%s", filename)
+			return fmt.Errorf("nil PhotoAttachment for attach://%s", filename)
 		}
 		photoField, errCreate := form.CreateFormFile(filename, filename)
 		if errCreate != nil {
-			return nil, errCreate
+			return errCreate
 		}
 		if _, err := io.Copy(photoField, live.PhotoAttachment); err != nil {
-			return nil, err
+			return err
 		}
 	}
-	return value.MarshalInputMedia()
+	return nil
 }
 
 func addFormFieldCustomMarshal(form *multipart.Writer, fieldName string, value customMarshal) error {
@@ -218,6 +230,88 @@ func addFormFieldInputMediaSlice(form *multipart.Writer, fieldName string, value
 	}
 	_, errCopy := io.Copy(w, strings.NewReader("["+strings.Join(lines, ",")+"]"))
 	return errCopy
+}
+
+// addFormFieldInputRichMessage adds the attach:// uploads referenced by a rich message
+// before encoding it, so that nested media is uploaded like top level InputMedia is.
+func addFormFieldInputRichMessage(form *multipart.Writer, fieldName string, value *models.InputRichMessage) error {
+	if err := addInputRichBlockSliceAttachments(form, value.Blocks); err != nil {
+		return err
+	}
+	for _, media := range value.Media {
+		if media.Media == nil {
+			continue
+		}
+		if err := addInputMediaAttachment(form, media.Media); err != nil {
+			return err
+		}
+	}
+	return addFormFieldDefault(form, fieldName, value)
+}
+
+func addInputRichBlockSliceAttachments(form *multipart.Writer, blocks []models.InputRichBlock) error {
+	for _, block := range blocks {
+		if err := addInputRichBlockAttachments(form, block); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// addInputRichBlockAttachments walks a single block: media blocks upload their attachment,
+// container blocks recurse into their nested blocks.
+func addInputRichBlockAttachments(form *multipart.Writer, block models.InputRichBlock) error {
+	switch block.Type {
+	case models.RichBlockTypeAnimation:
+		if block.InputRichBlockAnimation != nil {
+			return addInputMediaAttachment(form, &block.InputRichBlockAnimation.Animation)
+		}
+	case models.RichBlockTypeAudio:
+		if block.InputRichBlockAudio != nil {
+			return addInputMediaAttachment(form, &block.InputRichBlockAudio.Audio)
+		}
+	case models.RichBlockTypeDocument:
+		if block.InputRichBlockDocument != nil {
+			return addInputMediaAttachment(form, &block.InputRichBlockDocument.Document)
+		}
+	case models.RichBlockTypePhoto:
+		if block.InputRichBlockPhoto != nil {
+			return addInputMediaAttachment(form, &block.InputRichBlockPhoto.Photo)
+		}
+	case models.RichBlockTypeVideo:
+		if block.InputRichBlockVideo != nil {
+			return addInputMediaAttachment(form, &block.InputRichBlockVideo.Video)
+		}
+	case models.RichBlockTypeVoiceNote:
+		if block.InputRichBlockVoiceNote != nil {
+			return addInputMediaAttachment(form, &block.InputRichBlockVoiceNote.VoiceNote)
+		}
+	case models.RichBlockTypeList:
+		if block.InputRichBlockList != nil {
+			for _, item := range block.InputRichBlockList.Items {
+				if err := addInputRichBlockSliceAttachments(form, item.Blocks); err != nil {
+					return err
+				}
+			}
+		}
+	case models.RichBlockTypeBlockQuotation:
+		if block.InputRichBlockBlockQuotation != nil {
+			return addInputRichBlockSliceAttachments(form, block.InputRichBlockBlockQuotation.Blocks)
+		}
+	case models.RichBlockTypeCollage:
+		if block.InputRichBlockCollage != nil {
+			return addInputRichBlockSliceAttachments(form, block.InputRichBlockCollage.Blocks)
+		}
+	case models.RichBlockTypeSlideshow:
+		if block.InputRichBlockSlideshow != nil {
+			return addInputRichBlockSliceAttachments(form, block.InputRichBlockSlideshow.Blocks)
+		}
+	case models.RichBlockTypeDetails:
+		if block.InputRichBlockDetails != nil {
+			return addInputRichBlockSliceAttachments(form, block.InputRichBlockDetails.Blocks)
+		}
+	}
+	return nil
 }
 
 func addFormFieldInlineQueryResultSlice(form *multipart.Writer, fieldName string, value []models.InlineQueryResult) error {

--- a/build_request_form.go
+++ b/build_request_form.go
@@ -31,9 +31,37 @@ type mediaThumbnail interface {
 var customMarshalInterface = reflect.TypeOf(new(customMarshal)).Elem()
 var inputMediaInterface = reflect.TypeOf(new(inputMedia)).Elem()
 
+// formWriter is the part of multipart.Writer used to build a request, narrowed so the
+// created part names can be tracked, see requestForm.
+type formWriter interface {
+	CreateFormField(fieldName string) (io.Writer, error)
+	CreateFormFile(fieldName, filename string) (io.Writer, error)
+}
+
+// requestForm rejects two file parts sharing a name. The name of a part is what an
+// attach:// reference resolves against, so a duplicate silently makes Telegram resolve
+// both references to the first file.
+type requestForm struct {
+	formWriter
+	fileNames map[string]struct{}
+}
+
+func newRequestForm(w formWriter) *requestForm {
+	return &requestForm{formWriter: w, fileNames: map[string]struct{}{}}
+}
+
+func (f *requestForm) CreateFormFile(fieldName, filename string) (io.Writer, error) {
+	if _, ok := f.fileNames[fieldName]; ok {
+		return nil, fmt.Errorf("duplicate form part name %q", fieldName)
+	}
+	f.fileNames[fieldName] = struct{}{}
+	return f.formWriter.CreateFormFile(fieldName, filename)
+}
+
 // buildRequestForm builds form-data for request
 // if params contains InputFile of type InputFileUpload, it will be added to form-data ad upload file. Also, for InputMedia attachments
-func buildRequestForm(form *multipart.Writer, params any) (int, error) {
+func buildRequestForm(w *multipart.Writer, params any) (int, error) {
+	form := newRequestForm(w)
 	v := reflect.ValueOf(params).Elem()
 
 	var fieldsCount int
@@ -130,10 +158,16 @@ func buildRequestForm(form *multipart.Writer, params any) (int, error) {
 }
 
 func readerIsNil(r io.Reader) bool {
-	if r == nil {
+	return isNilValue(r)
+}
+
+// isNilValue reports whether a value is nil, including a typed nil pointer carried by
+// a non-nil interface, which an == nil check does not catch.
+func isNilValue(value any) bool {
+	if value == nil {
 		return true
 	}
-	v := reflect.ValueOf(r)
+	v := reflect.ValueOf(value)
 	switch v.Kind() {
 	case reflect.Pointer, reflect.Interface, reflect.Map, reflect.Slice, reflect.Chan, reflect.Func:
 		return v.IsNil()
@@ -142,7 +176,7 @@ func readerIsNil(r io.Reader) bool {
 	}
 }
 
-func addFormFieldInputFileUpload(form *multipart.Writer, fieldName string, value *models.InputFileUpload) error {
+func addFormFieldInputFileUpload(form formWriter, fieldName string, value *models.InputFileUpload) error {
 	if readerIsNil(value.Data) {
 		return fmt.Errorf("nil data for field %s", fieldName)
 	}
@@ -154,7 +188,7 @@ func addFormFieldInputFileUpload(form *multipart.Writer, fieldName string, value
 	return errCopy
 }
 
-func addFormFieldInputMediaItem(form *multipart.Writer, value inputMedia) ([]byte, error) {
+func addFormFieldInputMediaItem(form formWriter, value inputMedia) ([]byte, error) {
 	if err := addInputMediaAttachment(form, value); err != nil {
 		return nil, err
 	}
@@ -162,7 +196,7 @@ func addFormFieldInputMediaItem(form *multipart.Writer, value inputMedia) ([]byt
 }
 
 // addInputMediaAttachment adds the attach:// upload parts referenced by a media item, if any.
-func addInputMediaAttachment(form *multipart.Writer, value inputMedia) error {
+func addInputMediaAttachment(form formWriter, value inputMedia) error {
 	if strings.HasPrefix(value.GetMedia(), "attach://") {
 		filename := strings.TrimPrefix(value.GetMedia(), "attach://")
 		if readerIsNil(value.Attachment()) {
@@ -201,9 +235,9 @@ func addInputMediaAttachment(form *multipart.Writer, value inputMedia) error {
 // addInputFileAttachment uploads a nested InputFile, which is marshalled as an
 // attach:// reference instead of becoming a form field of its own. Anything but an
 // upload (a file_id or an URL) carries no content and is left to the encoder.
-func addInputFileAttachment(form *multipart.Writer, value models.InputFile) error {
+func addInputFileAttachment(form formWriter, value models.InputFile) error {
 	upload, ok := value.(*models.InputFileUpload)
-	if !ok {
+	if !ok || upload == nil {
 		return nil
 	}
 	if readerIsNil(upload.Data) {
@@ -217,7 +251,7 @@ func addInputFileAttachment(form *multipart.Writer, value models.InputFile) erro
 	return errCopy
 }
 
-func addFormFieldCustomMarshal(form *multipart.Writer, fieldName string, value customMarshal) error {
+func addFormFieldCustomMarshal(form formWriter, fieldName string, value customMarshal) error {
 	line, errEncode := value.MarshalCustom()
 	if errEncode != nil {
 		return errEncode
@@ -230,7 +264,7 @@ func addFormFieldCustomMarshal(form *multipart.Writer, fieldName string, value c
 	return errCopy
 }
 
-func addFormFieldInputMedia(form *multipart.Writer, fieldName string, value inputMedia) error {
+func addFormFieldInputMedia(form formWriter, fieldName string, value inputMedia) error {
 	line, err := addFormFieldInputMediaItem(form, value)
 	if err != nil {
 		return err
@@ -244,7 +278,7 @@ func addFormFieldInputMedia(form *multipart.Writer, fieldName string, value inpu
 	return errCopy
 }
 
-func addFormFieldInputMediaSlice(form *multipart.Writer, fieldName string, value []inputMedia) error {
+func addFormFieldInputMediaSlice(form formWriter, fieldName string, value []inputMedia) error {
 	var lines []string
 	for _, media := range value {
 		line, err := addFormFieldInputMediaItem(form, media)
@@ -264,12 +298,12 @@ func addFormFieldInputMediaSlice(form *multipart.Writer, fieldName string, value
 
 // addFormFieldInputRichMessage adds the attach:// uploads referenced by a rich message
 // before encoding it, so that nested media is uploaded like top level InputMedia is.
-func addFormFieldInputRichMessage(form *multipart.Writer, fieldName string, value *models.InputRichMessage) error {
+func addFormFieldInputRichMessage(form formWriter, fieldName string, value *models.InputRichMessage) error {
 	if err := addInputRichBlockSliceAttachments(form, value.Blocks); err != nil {
 		return err
 	}
 	for _, media := range value.Media {
-		if media.Media == nil {
+		if isNilValue(media.Media) {
 			continue
 		}
 		if err := addInputMediaAttachment(form, media.Media); err != nil {
@@ -279,7 +313,7 @@ func addFormFieldInputRichMessage(form *multipart.Writer, fieldName string, valu
 	return addFormFieldDefault(form, fieldName, value)
 }
 
-func addInputRichBlockSliceAttachments(form *multipart.Writer, blocks []models.InputRichBlock) error {
+func addInputRichBlockSliceAttachments(form formWriter, blocks []models.InputRichBlock) error {
 	for _, block := range blocks {
 		if err := addInputRichBlockAttachments(form, block); err != nil {
 			return err
@@ -290,7 +324,7 @@ func addInputRichBlockSliceAttachments(form *multipart.Writer, blocks []models.I
 
 // addInputRichBlockAttachments walks a single block: media blocks upload their attachment,
 // container blocks recurse into their nested blocks.
-func addInputRichBlockAttachments(form *multipart.Writer, block models.InputRichBlock) error {
+func addInputRichBlockAttachments(form formWriter, block models.InputRichBlock) error {
 	switch block.Type {
 	case models.RichBlockTypeAnimation:
 		if block.InputRichBlockAnimation != nil {
@@ -344,7 +378,7 @@ func addInputRichBlockAttachments(form *multipart.Writer, block models.InputRich
 	return nil
 }
 
-func addFormFieldInlineQueryResultSlice(form *multipart.Writer, fieldName string, value []models.InlineQueryResult) error {
+func addFormFieldInlineQueryResultSlice(form formWriter, fieldName string, value []models.InlineQueryResult) error {
 	var lines []string
 	for _, media := range value {
 		line, errEncode := media.MarshalCustom()
@@ -362,7 +396,7 @@ func addFormFieldInlineQueryResultSlice(form *multipart.Writer, fieldName string
 	return errCopy
 }
 
-func addFormFieldInputStickerSlice(form *multipart.Writer, fieldName string, value []models.InputSticker) error {
+func addFormFieldInputStickerSlice(form formWriter, fieldName string, value []models.InputSticker) error {
 	var lines []string
 	for _, sticker := range value {
 		if strings.HasPrefix(sticker.Sticker, "attach://") {
@@ -394,7 +428,7 @@ func addFormFieldInputStickerSlice(form *multipart.Writer, fieldName string, val
 	return errCopy
 }
 
-func addFormFieldDefault(form *multipart.Writer, fieldName string, value any) error {
+func addFormFieldDefault(form formWriter, fieldName string, value any) error {
 	d, errMarshal := json.Marshal(value)
 	if errMarshal != nil {
 		return errMarshal
@@ -408,7 +442,7 @@ func addFormFieldDefault(form *multipart.Writer, fieldName string, value any) er
 	return errCopy
 }
 
-func addFormFieldString(form *multipart.Writer, fieldName string, value string) error {
+func addFormFieldString(form formWriter, fieldName string, value string) error {
 	w, errCreateField := form.CreateFormField(fieldName)
 	if errCreateField != nil {
 		return errCreateField

--- a/build_request_form.go
+++ b/build_request_form.go
@@ -22,6 +22,12 @@ type customMarshal interface {
 	MarshalCustom() ([]byte, error)
 }
 
+// mediaThumbnail is implemented by the media types carrying a thumbnail, which is
+// uploaded as its own attach:// part instead of a form field of its own.
+type mediaThumbnail interface {
+	GetThumbnail() models.InputFile
+}
+
 var customMarshalInterface = reflect.TypeOf(new(customMarshal)).Elem()
 var inputMediaInterface = reflect.TypeOf(new(inputMedia)).Elem()
 
@@ -171,6 +177,11 @@ func addInputMediaAttachment(form *multipart.Writer, value inputMedia) error {
 			return errCopy
 		}
 	}
+	if thumbnailed, ok := value.(mediaThumbnail); ok {
+		if err := addInputFileAttachment(form, thumbnailed.GetThumbnail()); err != nil {
+			return err
+		}
+	}
 	if live, ok := value.(*models.InputMediaLivePhoto); ok && strings.HasPrefix(live.Photo, "attach://") {
 		filename := strings.TrimPrefix(live.Photo, "attach://")
 		if readerIsNil(live.PhotoAttachment) {
@@ -185,6 +196,25 @@ func addInputMediaAttachment(form *multipart.Writer, value inputMedia) error {
 		}
 	}
 	return nil
+}
+
+// addInputFileAttachment uploads a nested InputFile, which is marshalled as an
+// attach:// reference instead of becoming a form field of its own. Anything but an
+// upload (a file_id or an URL) carries no content and is left to the encoder.
+func addInputFileAttachment(form *multipart.Writer, value models.InputFile) error {
+	upload, ok := value.(*models.InputFileUpload)
+	if !ok {
+		return nil
+	}
+	if readerIsNil(upload.Data) {
+		return fmt.Errorf("nil data for attach://%s", upload.Filename)
+	}
+	w, errCreateField := form.CreateFormFile(upload.Filename, upload.Filename)
+	if errCreateField != nil {
+		return errCreateField
+	}
+	_, errCopy := io.Copy(w, upload.Data)
+	return errCopy
 }
 
 func addFormFieldCustomMarshal(form *multipart.Writer, fieldName string, value customMarshal) error {

--- a/build_request_form_test.go
+++ b/build_request_form_test.go
@@ -798,3 +798,106 @@ func Test_addInputMediaAttachment_writeErrors(t *testing.T) {
 		}
 	})
 }
+
+// A thumbnail left as a typed nil pointer is not an upload: it carries no data and
+// must not panic, the encoder writes it as null.
+func Test_buildRequestForm_typedNilThumbnail(t *testing.T) {
+	var thumb *models.InputFileUpload
+
+	params := SendMediaGroupParams{
+		ChatID: 1,
+		Media: []models.InputMedia{
+			&models.InputMediaVideo{
+				Media:           "attach://video.mp4",
+				MediaAttachment: strings.NewReader("video content"),
+				Thumbnail:       thumb,
+			},
+		},
+	}
+
+	buf := bytes.NewBuffer(nil)
+	form := multipart.NewWriter(buf)
+	form.SetBoundary("XXX") //nolint
+
+	if _, err := buildRequestForm(form, &params); err != nil {
+		t.Fatal(err)
+	}
+	if err := form.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(buf.String(), `[{"type":"video","media":"attach://video.mp4","thumbnail":null}]`) {
+		t.Fatalf("unexpected form data:\n%s", buf.String())
+	}
+}
+
+// An InputRichMessageMedia holding a typed nil pointer has nothing to upload; the
+// encoder is left to report it.
+func Test_addFormFieldInputRichMessage_typedNilMedia(t *testing.T) {
+	var doc *models.InputMediaDocument
+
+	buf := bytes.NewBuffer(nil)
+	form := multipart.NewWriter(buf)
+	form.SetBoundary("XXX") //nolint
+
+	err := addFormFieldInputRichMessage(form, "rich_message", &models.InputRichMessage{
+		Media: []models.InputRichMessageMedia{{ID: "doc1", Media: doc}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := form.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	assertEqualString(t, formFileNames(t, buf.String(), "XXX"), "")
+}
+
+// Two attachments sharing a part name would silently resolve to one file.
+func Test_buildRequestForm_duplicateThumbnailName(t *testing.T) {
+	params := SendMediaGroupParams{
+		ChatID: 1,
+		Media: []models.InputMedia{
+			&models.InputMediaVideo{
+				Media:           "attach://a.mp4",
+				MediaAttachment: strings.NewReader("a content"),
+				Thumbnail:       &models.InputFileUpload{Filename: "thumb.jpg", Data: strings.NewReader("thumb a")},
+			},
+			&models.InputMediaVideo{
+				Media:           "attach://b.mp4",
+				MediaAttachment: strings.NewReader("b content"),
+				Thumbnail:       &models.InputFileUpload{Filename: "thumb.jpg", Data: strings.NewReader("thumb b")},
+			},
+		},
+	}
+
+	form := multipart.NewWriter(bytes.NewBuffer(nil))
+
+	_, err := buildRequestForm(form, &params)
+	if err == nil {
+		t.Fatal("expected error for two parts named thumb.jpg")
+	}
+	if !strings.Contains(err.Error(), `duplicate form part name "thumb.jpg"`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func Test_buildRequestForm_duplicateMediaAttachName(t *testing.T) {
+	params := SendMediaGroupParams{
+		ChatID: 1,
+		Media: []models.InputMedia{
+			&models.InputMediaPhoto{Media: "attach://photo.jpg", MediaAttachment: strings.NewReader("a")},
+			&models.InputMediaPhoto{Media: "attach://photo.jpg", MediaAttachment: strings.NewReader("b")},
+		},
+	}
+
+	form := multipart.NewWriter(bytes.NewBuffer(nil))
+
+	_, err := buildRequestForm(form, &params)
+	if err == nil {
+		t.Fatal("expected error for two parts named photo.jpg")
+	}
+	if !strings.Contains(err.Error(), `duplicate form part name "photo.jpg"`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/build_request_form_test.go
+++ b/build_request_form_test.go
@@ -355,3 +355,83 @@ func Test_addFormFieldInputRichMessage_nilAttachment(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+func Test_buildRequestForm_inputMediaThumbnail(t *testing.T) {
+	params := struct {
+		Media     []models.InputMedia     `json:"media"`
+		PaidMedia []models.InputPaidMedia `json:"paid_media"`
+	}{
+		Media: []models.InputMedia{
+			&models.InputMediaVideo{
+				Media:           "attach://video.mp4",
+				MediaAttachment: strings.NewReader("video content"),
+				Thumbnail:       &models.InputFileUpload{Filename: "thumb.jpg", Data: strings.NewReader("thumb content")},
+			},
+			&models.InputMediaAudio{
+				Media:     "file_id",
+				Thumbnail: &models.InputFileString{Data: "https://domain.com/thumb.jpg"},
+			},
+		},
+		PaidMedia: []models.InputPaidMedia{
+			&models.InputPaidMediaVideo{
+				Media:     "file_id",
+				Thumbnail: &models.InputFileUpload{Filename: "paid_thumb.jpg", Data: strings.NewReader("paid thumb content")},
+			},
+		},
+	}
+
+	buf := bytes.NewBuffer(nil)
+	form := multipart.NewWriter(buf)
+	form.SetBoundary("XXX") //nolint
+
+	fieldsCount, errBuild := buildRequestForm(form, &params)
+	if errBuild != nil {
+		t.Error(errBuild)
+		return
+	}
+	if err := form.Close(); err != nil {
+		t.Errorf("failed to close form: %v", err)
+	}
+
+	expect := `--XXX
+Content-Disposition: form-data; name="video.mp4"; filename="video.mp4"
+Content-Type: application/octet-stream
+
+video content
+--XXX
+Content-Disposition: form-data; name="thumb.jpg"; filename="thumb.jpg"
+Content-Type: application/octet-stream
+
+thumb content
+--XXX
+Content-Disposition: form-data; name="media"
+
+[{"type":"video","media":"attach://video.mp4","thumbnail":"attach://thumb.jpg"},{"type":"audio","media":"file_id","thumbnail":"https://domain.com/thumb.jpg"}]
+--XXX
+Content-Disposition: form-data; name="paid_thumb.jpg"; filename="paid_thumb.jpg"
+Content-Type: application/octet-stream
+
+paid thumb content
+--XXX
+Content-Disposition: form-data; name="paid_media"
+
+[{"type":"video","media":"file_id","thumbnail":"attach://paid_thumb.jpg"}]
+--XXX--
+`
+	assertEqualInt(t, fieldsCount, 2)
+	assertFormData(t, buf.String(), expect)
+}
+
+func Test_addFormFieldInputMedia_nilThumbnailData(t *testing.T) {
+	form := multipart.NewWriter(bytes.NewBuffer(nil))
+	err := addFormFieldInputMedia(form, "media", &models.InputMediaVideo{
+		Media:     "file_id",
+		Thumbnail: &models.InputFileUpload{Filename: "thumb.jpg"},
+	})
+	if err == nil {
+		t.Fatal("expected error for thumbnail with nil Data")
+	}
+	if !strings.Contains(err.Error(), "nil data for attach://thumb.jpg") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/build_request_form_test.go
+++ b/build_request_form_test.go
@@ -2,6 +2,7 @@ package bot
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"mime/multipart"
 	"strings"
@@ -434,4 +435,366 @@ func Test_addFormFieldInputMedia_nilThumbnailData(t *testing.T) {
 	if !strings.Contains(err.Error(), "nil data for attach://thumb.jpg") {
 		t.Fatalf("unexpected error: %v", err)
 	}
+}
+
+type errWriter struct{}
+
+func (errWriter) Write([]byte) (int, error) {
+	return 0, errors.New("write failed")
+}
+
+// formFileNames returns the name of every file part of a built form, in order.
+func formFileNames(t *testing.T, body, boundary string) string {
+	t.Helper()
+
+	var names []string
+	r := multipart.NewReader(strings.NewReader(body), boundary)
+	for {
+		part, err := r.NextPart()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		if part.FileName() != "" {
+			names = append(names, part.FormName())
+		}
+	}
+
+	return strings.Join(names, ",")
+}
+
+func richDocumentBlock(name string) models.InputRichBlock {
+	return models.InputRichBlock{
+		Type: models.RichBlockTypeDocument,
+		InputRichBlockDocument: &models.InputRichBlockDocument{
+			Document: models.InputMediaDocument{
+				Media:           "attach://" + name,
+				MediaAttachment: strings.NewReader(name + " content"),
+			},
+		},
+	}
+}
+
+func Test_addInputRichBlockAttachments_mediaBlocks(t *testing.T) {
+	blocks := []models.InputRichBlock{
+		{
+			Type: models.RichBlockTypeAnimation,
+			InputRichBlockAnimation: &models.InputRichBlockAnimation{
+				Animation: models.InputMediaAnimation{Media: "attach://animation.gif", MediaAttachment: strings.NewReader("animation")},
+			},
+		},
+		{
+			Type: models.RichBlockTypeAudio,
+			InputRichBlockAudio: &models.InputRichBlockAudio{
+				Audio: models.InputMediaAudio{Media: "attach://audio.mp3", MediaAttachment: strings.NewReader("audio")},
+			},
+		},
+		richDocumentBlock("document.pdf"),
+		{
+			Type: models.RichBlockTypePhoto,
+			InputRichBlockPhoto: &models.InputRichBlockPhoto{
+				Photo: models.InputMediaPhoto{Media: "attach://photo.jpg", MediaAttachment: strings.NewReader("photo")},
+			},
+		},
+		{
+			Type: models.RichBlockTypeVideo,
+			InputRichBlockVideo: &models.InputRichBlockVideo{
+				Video: models.InputMediaVideo{
+					Media:           "attach://video.mp4",
+					MediaAttachment: strings.NewReader("video"),
+					Thumbnail:       &models.InputFileUpload{Filename: "video_thumb.jpg", Data: strings.NewReader("thumb")},
+				},
+			},
+		},
+		{
+			Type: models.RichBlockTypeVoiceNote,
+			InputRichBlockVoiceNote: &models.InputRichBlockVoiceNote{
+				VoiceNote: models.InputMediaVoiceNote{Media: "attach://voice.ogg", MediaAttachment: strings.NewReader("voice")},
+			},
+		},
+	}
+
+	buf := bytes.NewBuffer(nil)
+	form := multipart.NewWriter(buf)
+	form.SetBoundary("XXX") //nolint
+
+	if err := addInputRichBlockSliceAttachments(form, blocks); err != nil {
+		t.Fatal(err)
+	}
+	if err := form.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	assertEqualString(t,
+		formFileNames(t, buf.String(), "XXX"),
+		"animation.gif,audio.mp3,document.pdf,photo.jpg,video.mp4,video_thumb.jpg,voice.ogg",
+	)
+}
+
+func Test_addInputRichBlockAttachments_containerBlocks(t *testing.T) {
+	blocks := []models.InputRichBlock{
+		{
+			Type: models.RichBlockTypeList,
+			InputRichBlockList: &models.InputRichBlockList{
+				Items: []models.InputRichBlockListItem{{Blocks: []models.InputRichBlock{richDocumentBlock("list.pdf")}}},
+			},
+		},
+		{
+			Type: models.RichBlockTypeBlockQuotation,
+			InputRichBlockBlockQuotation: &models.InputRichBlockBlockQuotation{
+				Blocks: []models.InputRichBlock{richDocumentBlock("quote.pdf")},
+			},
+		},
+		{
+			Type: models.RichBlockTypeCollage,
+			InputRichBlockCollage: &models.InputRichBlockCollage{
+				Blocks: []models.InputRichBlock{richDocumentBlock("collage.pdf")},
+			},
+		},
+		{
+			Type: models.RichBlockTypeSlideshow,
+			InputRichBlockSlideshow: &models.InputRichBlockSlideshow{
+				Blocks: []models.InputRichBlock{richDocumentBlock("slideshow.pdf")},
+			},
+		},
+		{
+			Type: models.RichBlockTypeDetails,
+			InputRichBlockDetails: &models.InputRichBlockDetails{
+				Blocks: []models.InputRichBlock{richDocumentBlock("details.pdf")},
+			},
+		},
+	}
+
+	buf := bytes.NewBuffer(nil)
+	form := multipart.NewWriter(buf)
+	form.SetBoundary("XXX") //nolint
+
+	if err := addInputRichBlockSliceAttachments(form, blocks); err != nil {
+		t.Fatal(err)
+	}
+	if err := form.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	assertEqualString(t,
+		formFileNames(t, buf.String(), "XXX"),
+		"list.pdf,quote.pdf,collage.pdf,slideshow.pdf,details.pdf",
+	)
+}
+
+// A block whose variant pointer is not set carries no attachment. The encoder
+// reports the broken union; the walk must not panic on the way there.
+func Test_addInputRichBlockAttachments_missingVariant(t *testing.T) {
+	types := []models.RichBlockType{
+		models.RichBlockTypeAnimation,
+		models.RichBlockTypeAudio,
+		models.RichBlockTypeDocument,
+		models.RichBlockTypePhoto,
+		models.RichBlockTypeVideo,
+		models.RichBlockTypeVoiceNote,
+		models.RichBlockTypeList,
+		models.RichBlockTypeBlockQuotation,
+		models.RichBlockTypeCollage,
+		models.RichBlockTypeSlideshow,
+		models.RichBlockTypeDetails,
+		models.RichBlockTypeParagraph,
+	}
+
+	buf := bytes.NewBuffer(nil)
+	form := multipart.NewWriter(buf)
+	form.SetBoundary("XXX") //nolint
+
+	for _, blockType := range types {
+		if err := addInputRichBlockAttachments(form, models.InputRichBlock{Type: blockType}); err != nil {
+			t.Fatalf("%s: %v", blockType, err)
+		}
+	}
+	if err := form.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	assertEqualString(t, formFileNames(t, buf.String(), "XXX"), "")
+}
+
+func Test_addFormFieldInputRichMessage_nilAttachmentInNestedBlock(t *testing.T) {
+	form := multipart.NewWriter(bytes.NewBuffer(nil))
+	err := addFormFieldInputRichMessage(form, "rich_message", &models.InputRichMessage{
+		Blocks: []models.InputRichBlock{
+			{
+				Type: models.RichBlockTypeCollage,
+				InputRichBlockCollage: &models.InputRichBlockCollage{
+					Blocks: []models.InputRichBlock{
+						{
+							Type: models.RichBlockTypeDocument,
+							InputRichBlockDocument: &models.InputRichBlockDocument{
+								Document: models.InputMediaDocument{Media: "attach://doc1.pdf"},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error for attach:// with nil MediaAttachment")
+	}
+	if !strings.Contains(err.Error(), "nil attachment for attach://doc1.pdf") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func Test_addInputRichBlockAttachments_nilAttachmentInListItem(t *testing.T) {
+	form := multipart.NewWriter(bytes.NewBuffer(nil))
+	err := addInputRichBlockAttachments(form, models.InputRichBlock{
+		Type: models.RichBlockTypeList,
+		InputRichBlockList: &models.InputRichBlockList{
+			Items: []models.InputRichBlockListItem{
+				{
+					Blocks: []models.InputRichBlock{
+						{
+							Type: models.RichBlockTypeDocument,
+							InputRichBlockDocument: &models.InputRichBlockDocument{
+								Document: models.InputMediaDocument{Media: "attach://doc1.pdf"},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error for attach:// with nil MediaAttachment")
+	}
+	if !strings.Contains(err.Error(), "nil attachment for attach://doc1.pdf") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// An InputRichMessageMedia with no media has nothing to upload; the encoder is
+// left to report it.
+func Test_addFormFieldInputRichMessage_nilMedia(t *testing.T) {
+	buf := bytes.NewBuffer(nil)
+	form := multipart.NewWriter(buf)
+	form.SetBoundary("XXX") //nolint
+
+	err := addFormFieldInputRichMessage(form, "rich_message", &models.InputRichMessage{
+		Media: []models.InputRichMessageMedia{{ID: "doc1"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := form.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	assertEqualString(t, formFileNames(t, buf.String(), "XXX"), "")
+}
+
+func Test_addFormFieldInputMedia_livePhoto(t *testing.T) {
+	buf := bytes.NewBuffer(nil)
+	form := multipart.NewWriter(buf)
+	form.SetBoundary("XXX") //nolint
+
+	err := addFormFieldInputMedia(form, "media", &models.InputMediaLivePhoto{
+		Media:           "attach://live.jpg",
+		MediaAttachment: strings.NewReader("still content"),
+		Photo:           "attach://live.mov",
+		PhotoAttachment: strings.NewReader("motion content"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := form.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	assertEqualString(t, formFileNames(t, buf.String(), "XXX"), "live.jpg,live.mov")
+}
+
+func Test_addFormFieldInputMedia_livePhotoNilPhotoAttachment(t *testing.T) {
+	form := multipart.NewWriter(bytes.NewBuffer(nil))
+	err := addFormFieldInputMedia(form, "media", &models.InputMediaLivePhoto{
+		Media: "file_id",
+		Photo: "attach://live.mov",
+	})
+	if err == nil {
+		t.Fatal("expected error for attach:// with nil PhotoAttachment")
+	}
+	if !strings.Contains(err.Error(), "nil PhotoAttachment for attach://live.mov") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func Test_addInputMediaAttachment_readErrors(t *testing.T) {
+	t.Run("media", func(t *testing.T) {
+		form := multipart.NewWriter(bytes.NewBuffer(nil))
+		err := addInputMediaAttachment(form, &models.InputMediaPhoto{
+			Media:           "attach://photo.jpg",
+			MediaAttachment: errReader(errors.New("read failed")),
+		})
+		if err == nil || !strings.Contains(err.Error(), "read failed") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("live photo", func(t *testing.T) {
+		form := multipart.NewWriter(bytes.NewBuffer(nil))
+		err := addInputMediaAttachment(form, &models.InputMediaLivePhoto{
+			Media:           "file_id",
+			Photo:           "attach://live.mov",
+			PhotoAttachment: errReader(errors.New("read failed")),
+		})
+		if err == nil || !strings.Contains(err.Error(), "read failed") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("thumbnail", func(t *testing.T) {
+		form := multipart.NewWriter(bytes.NewBuffer(nil))
+		err := addInputMediaAttachment(form, &models.InputMediaVideo{
+			Media:     "file_id",
+			Thumbnail: &models.InputFileUpload{Filename: "thumb.jpg", Data: errReader(errors.New("read failed"))},
+		})
+		if err == nil || !strings.Contains(err.Error(), "read failed") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+func Test_addInputMediaAttachment_writeErrors(t *testing.T) {
+	t.Run("media", func(t *testing.T) {
+		form := multipart.NewWriter(errWriter{})
+		err := addInputMediaAttachment(form, &models.InputMediaPhoto{
+			Media:           "attach://photo.jpg",
+			MediaAttachment: strings.NewReader("photo"),
+		})
+		if err == nil || !strings.Contains(err.Error(), "write failed") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("live photo", func(t *testing.T) {
+		form := multipart.NewWriter(errWriter{})
+		err := addInputMediaAttachment(form, &models.InputMediaLivePhoto{
+			Media:           "file_id",
+			Photo:           "attach://live.mov",
+			PhotoAttachment: strings.NewReader("motion"),
+		})
+		if err == nil || !strings.Contains(err.Error(), "write failed") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("thumbnail", func(t *testing.T) {
+		form := multipart.NewWriter(errWriter{})
+		err := addInputMediaAttachment(form, &models.InputMediaVideo{
+			Media:     "file_id",
+			Thumbnail: &models.InputFileUpload{Filename: "thumb.jpg", Data: strings.NewReader("thumb")},
+		})
+		if err == nil || !strings.Contains(err.Error(), "write failed") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
 }

--- a/build_request_form_test.go
+++ b/build_request_form_test.go
@@ -19,7 +19,8 @@ func (structReader) Read(p []byte) (int, error) {
 
 func Test_addFormFieldInputFileUpload_structReaderDoesNotPanic(t *testing.T) {
 	buf := bytes.NewBuffer(nil)
-	form := multipart.NewWriter(buf)
+	writer := multipart.NewWriter(buf)
+	form := newRequestForm(writer)
 	err := addFormFieldInputFileUpload(form, "file", &models.InputFileUpload{
 		Filename: "x.bin",
 		Data:     structReader{},
@@ -27,7 +28,7 @@ func Test_addFormFieldInputFileUpload_structReaderDoesNotPanic(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := form.Close(); err != nil {
+	if err := writer.Close(); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -172,7 +173,8 @@ Content-Disposition: form-data; name="input_sticker_slice"
 }
 
 func Test_addFormFieldInputMedia_nilAttachment(t *testing.T) {
-	form := multipart.NewWriter(bytes.NewBuffer(nil))
+	writer := multipart.NewWriter(bytes.NewBuffer(nil))
+	form := newRequestForm(writer)
 	err := addFormFieldInputMedia(form, "media", &models.InputMediaPhoto{
 		Media: "attach://photo.png",
 	})
@@ -185,7 +187,8 @@ func Test_addFormFieldInputMedia_nilAttachment(t *testing.T) {
 }
 
 func Test_addFormFieldInputStickerSlice_nilAttachment(t *testing.T) {
-	form := multipart.NewWriter(bytes.NewBuffer(nil))
+	writer := multipart.NewWriter(bytes.NewBuffer(nil))
+	form := newRequestForm(writer)
 	err := addFormFieldInputStickerSlice(form, "stickers", []models.InputSticker{{
 		Sticker: "attach://sticker.png",
 		Format:  "static",
@@ -343,7 +346,8 @@ Content-Disposition: form-data; name="rich_message"
 }
 
 func Test_addFormFieldInputRichMessage_nilAttachment(t *testing.T) {
-	form := multipart.NewWriter(bytes.NewBuffer(nil))
+	writer := multipart.NewWriter(bytes.NewBuffer(nil))
+	form := newRequestForm(writer)
 	err := addFormFieldInputRichMessage(form, "rich_message", &models.InputRichMessage{
 		Media: []models.InputRichMessageMedia{
 			{ID: "doc1", Media: &models.InputMediaDocument{Media: "attach://doc1.pdf"}},
@@ -424,7 +428,8 @@ Content-Disposition: form-data; name="paid_media"
 }
 
 func Test_addFormFieldInputMedia_nilThumbnailData(t *testing.T) {
-	form := multipart.NewWriter(bytes.NewBuffer(nil))
+	writer := multipart.NewWriter(bytes.NewBuffer(nil))
+	form := newRequestForm(writer)
 	err := addFormFieldInputMedia(form, "media", &models.InputMediaVideo{
 		Media:     "file_id",
 		Thumbnail: &models.InputFileUpload{Filename: "thumb.jpg"},
@@ -517,13 +522,14 @@ func Test_addInputRichBlockAttachments_mediaBlocks(t *testing.T) {
 	}
 
 	buf := bytes.NewBuffer(nil)
-	form := multipart.NewWriter(buf)
-	form.SetBoundary("XXX") //nolint
+	writer := multipart.NewWriter(buf)
+	form := newRequestForm(writer)
+	writer.SetBoundary("XXX") //nolint
 
 	if err := addInputRichBlockSliceAttachments(form, blocks); err != nil {
 		t.Fatal(err)
 	}
-	if err := form.Close(); err != nil {
+	if err := writer.Close(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -568,13 +574,14 @@ func Test_addInputRichBlockAttachments_containerBlocks(t *testing.T) {
 	}
 
 	buf := bytes.NewBuffer(nil)
-	form := multipart.NewWriter(buf)
-	form.SetBoundary("XXX") //nolint
+	writer := multipart.NewWriter(buf)
+	form := newRequestForm(writer)
+	writer.SetBoundary("XXX") //nolint
 
 	if err := addInputRichBlockSliceAttachments(form, blocks); err != nil {
 		t.Fatal(err)
 	}
-	if err := form.Close(); err != nil {
+	if err := writer.Close(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -603,15 +610,16 @@ func Test_addInputRichBlockAttachments_missingVariant(t *testing.T) {
 	}
 
 	buf := bytes.NewBuffer(nil)
-	form := multipart.NewWriter(buf)
-	form.SetBoundary("XXX") //nolint
+	writer := multipart.NewWriter(buf)
+	form := newRequestForm(writer)
+	writer.SetBoundary("XXX") //nolint
 
 	for _, blockType := range types {
 		if err := addInputRichBlockAttachments(form, models.InputRichBlock{Type: blockType}); err != nil {
 			t.Fatalf("%s: %v", blockType, err)
 		}
 	}
-	if err := form.Close(); err != nil {
+	if err := writer.Close(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -619,7 +627,8 @@ func Test_addInputRichBlockAttachments_missingVariant(t *testing.T) {
 }
 
 func Test_addFormFieldInputRichMessage_nilAttachmentInNestedBlock(t *testing.T) {
-	form := multipart.NewWriter(bytes.NewBuffer(nil))
+	writer := multipart.NewWriter(bytes.NewBuffer(nil))
+	form := newRequestForm(writer)
 	err := addFormFieldInputRichMessage(form, "rich_message", &models.InputRichMessage{
 		Blocks: []models.InputRichBlock{
 			{
@@ -646,7 +655,8 @@ func Test_addFormFieldInputRichMessage_nilAttachmentInNestedBlock(t *testing.T) 
 }
 
 func Test_addInputRichBlockAttachments_nilAttachmentInListItem(t *testing.T) {
-	form := multipart.NewWriter(bytes.NewBuffer(nil))
+	writer := multipart.NewWriter(bytes.NewBuffer(nil))
+	form := newRequestForm(writer)
 	err := addInputRichBlockAttachments(form, models.InputRichBlock{
 		Type: models.RichBlockTypeList,
 		InputRichBlockList: &models.InputRichBlockList{
@@ -672,30 +682,27 @@ func Test_addInputRichBlockAttachments_nilAttachmentInListItem(t *testing.T) {
 	}
 }
 
-// An InputRichMessageMedia with no media has nothing to upload; the encoder is
-// left to report it.
+// The media of an InputRichMessageMedia is required, so a missing one cannot be
+// encoded as a null and left to the server to reject.
 func Test_addFormFieldInputRichMessage_nilMedia(t *testing.T) {
-	buf := bytes.NewBuffer(nil)
-	form := multipart.NewWriter(buf)
-	form.SetBoundary("XXX") //nolint
+	form := newRequestForm(multipart.NewWriter(bytes.NewBuffer(nil)))
 
 	err := addFormFieldInputRichMessage(form, "rich_message", &models.InputRichMessage{
 		Media: []models.InputRichMessageMedia{{ID: "doc1"}},
 	})
-	if err != nil {
-		t.Fatal(err)
+	if err == nil {
+		t.Fatal("expected error for an entry with no media")
 	}
-	if err := form.Close(); err != nil {
-		t.Fatal(err)
+	if !strings.Contains(err.Error(), "nil media for field rich_message at index 0") {
+		t.Fatalf("unexpected error: %v", err)
 	}
-
-	assertEqualString(t, formFileNames(t, buf.String(), "XXX"), "")
 }
 
 func Test_addFormFieldInputMedia_livePhoto(t *testing.T) {
 	buf := bytes.NewBuffer(nil)
-	form := multipart.NewWriter(buf)
-	form.SetBoundary("XXX") //nolint
+	writer := multipart.NewWriter(buf)
+	form := newRequestForm(writer)
+	writer.SetBoundary("XXX") //nolint
 
 	err := addFormFieldInputMedia(form, "media", &models.InputMediaLivePhoto{
 		Media:           "attach://live.jpg",
@@ -706,7 +713,7 @@ func Test_addFormFieldInputMedia_livePhoto(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := form.Close(); err != nil {
+	if err := writer.Close(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -714,7 +721,8 @@ func Test_addFormFieldInputMedia_livePhoto(t *testing.T) {
 }
 
 func Test_addFormFieldInputMedia_livePhotoNilPhotoAttachment(t *testing.T) {
-	form := multipart.NewWriter(bytes.NewBuffer(nil))
+	writer := multipart.NewWriter(bytes.NewBuffer(nil))
+	form := newRequestForm(writer)
 	err := addFormFieldInputMedia(form, "media", &models.InputMediaLivePhoto{
 		Media: "file_id",
 		Photo: "attach://live.mov",
@@ -729,7 +737,8 @@ func Test_addFormFieldInputMedia_livePhotoNilPhotoAttachment(t *testing.T) {
 
 func Test_addInputMediaAttachment_readErrors(t *testing.T) {
 	t.Run("media", func(t *testing.T) {
-		form := multipart.NewWriter(bytes.NewBuffer(nil))
+		writer := multipart.NewWriter(bytes.NewBuffer(nil))
+		form := newRequestForm(writer)
 		err := addInputMediaAttachment(form, &models.InputMediaPhoto{
 			Media:           "attach://photo.jpg",
 			MediaAttachment: errReader(errors.New("read failed")),
@@ -740,7 +749,8 @@ func Test_addInputMediaAttachment_readErrors(t *testing.T) {
 	})
 
 	t.Run("live photo", func(t *testing.T) {
-		form := multipart.NewWriter(bytes.NewBuffer(nil))
+		writer := multipart.NewWriter(bytes.NewBuffer(nil))
+		form := newRequestForm(writer)
 		err := addInputMediaAttachment(form, &models.InputMediaLivePhoto{
 			Media:           "file_id",
 			Photo:           "attach://live.mov",
@@ -752,7 +762,8 @@ func Test_addInputMediaAttachment_readErrors(t *testing.T) {
 	})
 
 	t.Run("thumbnail", func(t *testing.T) {
-		form := multipart.NewWriter(bytes.NewBuffer(nil))
+		writer := multipart.NewWriter(bytes.NewBuffer(nil))
+		form := newRequestForm(writer)
 		err := addInputMediaAttachment(form, &models.InputMediaVideo{
 			Media:     "file_id",
 			Thumbnail: &models.InputFileUpload{Filename: "thumb.jpg", Data: errReader(errors.New("read failed"))},
@@ -765,7 +776,8 @@ func Test_addInputMediaAttachment_readErrors(t *testing.T) {
 
 func Test_addInputMediaAttachment_writeErrors(t *testing.T) {
 	t.Run("media", func(t *testing.T) {
-		form := multipart.NewWriter(errWriter{})
+		writer := multipart.NewWriter(errWriter{})
+		form := newRequestForm(writer)
 		err := addInputMediaAttachment(form, &models.InputMediaPhoto{
 			Media:           "attach://photo.jpg",
 			MediaAttachment: strings.NewReader("photo"),
@@ -776,7 +788,8 @@ func Test_addInputMediaAttachment_writeErrors(t *testing.T) {
 	})
 
 	t.Run("live photo", func(t *testing.T) {
-		form := multipart.NewWriter(errWriter{})
+		writer := multipart.NewWriter(errWriter{})
+		form := newRequestForm(writer)
 		err := addInputMediaAttachment(form, &models.InputMediaLivePhoto{
 			Media:           "file_id",
 			Photo:           "attach://live.mov",
@@ -788,7 +801,8 @@ func Test_addInputMediaAttachment_writeErrors(t *testing.T) {
 	})
 
 	t.Run("thumbnail", func(t *testing.T) {
-		form := multipart.NewWriter(errWriter{})
+		writer := multipart.NewWriter(errWriter{})
+		form := newRequestForm(writer)
 		err := addInputMediaAttachment(form, &models.InputMediaVideo{
 			Media:     "file_id",
 			Thumbnail: &models.InputFileUpload{Filename: "thumb.jpg", Data: strings.NewReader("thumb")},
@@ -799,8 +813,8 @@ func Test_addInputMediaAttachment_writeErrors(t *testing.T) {
 	})
 }
 
-// A thumbnail left as a typed nil pointer is not an upload: it carries no data and
-// must not panic, the encoder writes it as null.
+// A thumbnail left as a typed nil pointer is not a thumbnail: it carries no data and
+// must not panic, and the key is omitted rather than sent as a null.
 func Test_buildRequestForm_typedNilThumbnail(t *testing.T) {
 	var thumb *models.InputFileUpload
 
@@ -826,31 +840,26 @@ func Test_buildRequestForm_typedNilThumbnail(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !strings.Contains(buf.String(), `[{"type":"video","media":"attach://video.mp4","thumbnail":null}]`) {
+	if !strings.Contains(buf.String(), `[{"type":"video","media":"attach://video.mp4"}]`) {
 		t.Fatalf("unexpected form data:\n%s", buf.String())
 	}
 }
 
-// An InputRichMessageMedia holding a typed nil pointer has nothing to upload; the
-// encoder is left to report it.
+// An InputRichMessageMedia holding a typed nil pointer carries no media either.
 func Test_addFormFieldInputRichMessage_typedNilMedia(t *testing.T) {
 	var doc *models.InputMediaDocument
 
-	buf := bytes.NewBuffer(nil)
-	form := multipart.NewWriter(buf)
-	form.SetBoundary("XXX") //nolint
+	form := newRequestForm(multipart.NewWriter(bytes.NewBuffer(nil)))
 
 	err := addFormFieldInputRichMessage(form, "rich_message", &models.InputRichMessage{
 		Media: []models.InputRichMessageMedia{{ID: "doc1", Media: doc}},
 	})
-	if err != nil {
-		t.Fatal(err)
+	if err == nil {
+		t.Fatal("expected error for a typed nil media")
 	}
-	if err := form.Close(); err != nil {
-		t.Fatal(err)
+	if !strings.Contains(err.Error(), "nil media for field rich_message at index 0") {
+		t.Fatalf("unexpected error: %v", err)
 	}
-
-	assertEqualString(t, formFileNames(t, buf.String(), "XXX"), "")
 }
 
 // Two attachments sharing a part name would silently resolve to one file.
@@ -898,6 +907,253 @@ func Test_buildRequestForm_duplicateMediaAttachName(t *testing.T) {
 		t.Fatal("expected error for two parts named photo.jpg")
 	}
 	if !strings.Contains(err.Error(), `duplicate form part name "photo.jpg"`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// A typed nil pointer in a top level InputFile field carries no data. It must be
+// reported, not dereferenced: the form is built in a goroutine with no recover.
+func Test_buildRequestForm_topLevelTypedNilInputFile(t *testing.T) {
+	var thumb *models.InputFileUpload
+
+	params := SendVideoParams{
+		ChatID:    1,
+		Video:     &models.InputFileString{Data: "file_id"},
+		Thumbnail: thumb,
+	}
+
+	form := multipart.NewWriter(bytes.NewBuffer(nil))
+
+	_, err := buildRequestForm(form, &params)
+	if err == nil {
+		t.Fatal("expected error for typed nil thumbnail")
+	}
+	if !strings.Contains(err.Error(), "nil value for field thumbnail") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// Same for a typed nil element of a media slice.
+func Test_buildRequestForm_typedNilMediaSliceItem(t *testing.T) {
+	params := SendMediaGroupParams{
+		ChatID: 1,
+		Media: []models.InputMedia{
+			&models.InputMediaPhoto{Media: "file_id"},
+			(*models.InputMediaPhoto)(nil),
+		},
+	}
+
+	form := multipart.NewWriter(bytes.NewBuffer(nil))
+
+	_, err := buildRequestForm(form, &params)
+	if err == nil {
+		t.Fatal("expected error for typed nil media item")
+	}
+	if !strings.Contains(err.Error(), "nil value for field media at index 1") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// A typed nil in a single InputMedia field is the same class of value.
+func Test_buildRequestForm_typedNilMediaField(t *testing.T) {
+	params := EditMessageMediaParams{
+		Media: (*models.InputMediaPhoto)(nil),
+	}
+
+	form := multipart.NewWriter(bytes.NewBuffer(nil))
+
+	_, err := buildRequestForm(form, &params)
+	if err == nil {
+		t.Fatal("expected error for typed nil media field")
+	}
+	if !strings.Contains(err.Error(), "nil value for field media") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// One file referenced from two entries under a single attach:// name is a single
+// part, not an ambiguity: the part already written is reused.
+func Test_buildRequestForm_repeatedAttachNameSameReader(t *testing.T) {
+	photo := strings.NewReader("photo content")
+
+	params := SendMediaGroupParams{
+		ChatID: 1,
+		Media: []models.InputMedia{
+			&models.InputMediaPhoto{Media: "attach://p.jpg", MediaAttachment: photo},
+			&models.InputMediaPhoto{Media: "attach://p.jpg", MediaAttachment: photo},
+		},
+	}
+
+	buf := bytes.NewBuffer(nil)
+	form := multipart.NewWriter(buf)
+	form.SetBoundary("XXX") //nolint
+
+	if _, err := buildRequestForm(form, &params); err != nil {
+		t.Fatal(err)
+	}
+	if err := form.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	assertEqualString(t, formFileNames(t, buf.String(), "XXX"), "p.jpg")
+}
+
+// The second entry may leave the attachment out entirely and just carry the reference.
+func Test_buildRequestForm_repeatedAttachNameWithoutReader(t *testing.T) {
+	params := SendMediaGroupParams{
+		ChatID: 1,
+		Media: []models.InputMedia{
+			&models.InputMediaPhoto{Media: "attach://p.jpg", MediaAttachment: strings.NewReader("photo content")},
+			&models.InputMediaPhoto{Media: "attach://p.jpg"},
+		},
+	}
+
+	buf := bytes.NewBuffer(nil)
+	form := multipart.NewWriter(buf)
+	form.SetBoundary("XXX") //nolint
+
+	if _, err := buildRequestForm(form, &params); err != nil {
+		t.Fatal(err)
+	}
+	if err := form.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	assertEqualString(t, formFileNames(t, buf.String(), "XXX"), "p.jpg")
+}
+
+// One sticker image reused across two entries of a set.
+func Test_buildRequestForm_repeatedStickerAttachName(t *testing.T) {
+	sticker := strings.NewReader("sticker content")
+
+	params := CreateNewStickerSetParams{
+		Name:  "set",
+		Title: "set",
+		Stickers: []models.InputSticker{
+			{Sticker: "attach://s.png", StickerAttachment: sticker, EmojiList: []string{"a"}},
+			{Sticker: "attach://s.png", StickerAttachment: sticker, EmojiList: []string{"b"}},
+		},
+	}
+
+	buf := bytes.NewBuffer(nil)
+	form := multipart.NewWriter(buf)
+	form.SetBoundary("XXX") //nolint
+
+	if _, err := buildRequestForm(form, &params); err != nil {
+		t.Fatal(err)
+	}
+	if err := form.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	assertEqualString(t, formFileNames(t, buf.String(), "XXX"), "s.png")
+}
+
+// Two different files still cannot share one name.
+func Test_buildRequestForm_repeatedAttachNameDifferentReader(t *testing.T) {
+	params := SendMediaGroupParams{
+		ChatID: 1,
+		Media: []models.InputMedia{
+			&models.InputMediaPhoto{Media: "attach://p.jpg", MediaAttachment: strings.NewReader("a")},
+			&models.InputMediaPhoto{Media: "attach://p.jpg", MediaAttachment: strings.NewReader("b")},
+		},
+	}
+
+	form := multipart.NewWriter(bytes.NewBuffer(nil))
+
+	_, err := buildRequestForm(form, &params)
+	if err == nil {
+		t.Fatal("expected error for two files named p.jpg")
+	}
+	if !strings.Contains(err.Error(), `duplicate form part name "p.jpg"`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// A file part and a form field sharing a name is the ambiguity the check exists for.
+func Test_buildRequestForm_filePartCollidesWithField(t *testing.T) {
+	params := EditMessageMediaParams{
+		Media: &models.InputMediaVideo{Media: "attach://media", MediaAttachment: strings.NewReader("video")},
+	}
+
+	form := multipart.NewWriter(bytes.NewBuffer(nil))
+
+	_, err := buildRequestForm(form, &params)
+	if err == nil {
+		t.Fatal("expected error for a file part named like a form field")
+	}
+	if !strings.Contains(err.Error(), `duplicate form part name "media"`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// A nested upload with no Filename would be written as a part named "" and referenced
+// as "attach://", which Telegram can only answer with an opaque Bad Request.
+func Test_addInputFileAttachment_emptyFilename(t *testing.T) {
+	form := newRequestForm(multipart.NewWriter(bytes.NewBuffer(nil)))
+
+	err := addInputFileAttachment(form, &models.InputFileUpload{Data: strings.NewReader("thumb")})
+	if err == nil {
+		t.Fatal("expected error for an upload with no filename")
+	}
+	if !strings.Contains(err.Error(), "empty filename") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// sliceReader is a reader that cannot be compared, so it can never be recognised as
+// one file referenced twice.
+type sliceReader []byte
+
+func (sliceReader) Read([]byte) (int, error) {
+	return 0, io.EOF
+}
+
+func Test_requestForm_addFilePart_incomparableReader(t *testing.T) {
+	form := newRequestForm(multipart.NewWriter(bytes.NewBuffer(nil)))
+
+	if err := form.addFilePart("p.jpg", "p.jpg", sliceReader("a")); err != nil {
+		t.Fatal(err)
+	}
+
+	err := form.addFilePart("p.jpg", "p.jpg", sliceReader("a"))
+	if err == nil {
+		t.Fatal("expected error for a second reader under one part name")
+	}
+	if !strings.Contains(err.Error(), `duplicate form part name "p.jpg"`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func Test_requestForm_addFieldPart_duplicate(t *testing.T) {
+	form := newRequestForm(multipart.NewWriter(bytes.NewBuffer(nil)))
+
+	if err := form.addFieldPart("media", strings.NewReader("a")); err != nil {
+		t.Fatal(err)
+	}
+
+	err := form.addFieldPart("media", strings.NewReader("b"))
+	if err == nil {
+		t.Fatal("expected error for two fields named media")
+	}
+	if !strings.Contains(err.Error(), `duplicate form part name "media"`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// A form field cannot take the name of a file part written before it either.
+func Test_requestForm_addFilePart_collidesWithField(t *testing.T) {
+	form := newRequestForm(multipart.NewWriter(bytes.NewBuffer(nil)))
+
+	if err := form.addFieldPart("media", strings.NewReader("a")); err != nil {
+		t.Fatal(err)
+	}
+
+	err := form.addFilePart("media", "media", strings.NewReader("b"))
+	if err == nil {
+		t.Fatal("expected error for a file part named like a form field")
+	}
+	if !strings.Contains(err.Error(), `duplicate form part name "media"`) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/build_request_form_test.go
+++ b/build_request_form_test.go
@@ -196,3 +196,162 @@ func Test_addFormFieldInputStickerSlice_nilAttachment(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+func Test_buildRequestForm_inputRichMessageMedia(t *testing.T) {
+	params := struct {
+		RichMessage models.InputRichMessage `json:"rich_message"`
+	}{
+		RichMessage: models.InputRichMessage{
+			HTML: "tg://document?id=doc1",
+			Media: []models.InputRichMessageMedia{
+				{
+					ID: "doc1",
+					Media: &models.InputMediaDocument{
+						Media:           "attach://doc1.pdf",
+						MediaAttachment: strings.NewReader("document content"),
+					},
+				},
+				{
+					ID:    "doc2",
+					Media: &models.InputMediaDocument{Media: "file_id"},
+				},
+			},
+		},
+	}
+
+	buf := bytes.NewBuffer(nil)
+	form := multipart.NewWriter(buf)
+	form.SetBoundary("XXX") //nolint
+
+	fieldsCount, errBuild := buildRequestForm(form, &params)
+	if errBuild != nil {
+		t.Error(errBuild)
+		return
+	}
+	if err := form.Close(); err != nil {
+		t.Errorf("failed to close form: %v", err)
+	}
+
+	expect := `--XXX
+Content-Disposition: form-data; name="doc1.pdf"; filename="doc1.pdf"
+Content-Type: application/octet-stream
+
+document content
+--XXX
+Content-Disposition: form-data; name="rich_message"
+
+{"html":"tg://document?id=doc1","media":[{"id":"doc1","media":{"type":"document","media":"attach://doc1.pdf"}},{"id":"doc2","media":{"type":"document","media":"file_id"}}]}
+--XXX--
+`
+	assertEqualInt(t, fieldsCount, 1)
+	assertFormData(t, buf.String(), expect)
+}
+
+func Test_buildRequestForm_inputRichMessageBlocks(t *testing.T) {
+	params := struct {
+		RichMessage *models.InputRichMessage `json:"rich_message"`
+	}{
+		RichMessage: &models.InputRichMessage{
+			Blocks: []models.InputRichBlock{
+				{
+					Type: models.RichBlockTypePhoto,
+					InputRichBlockPhoto: &models.InputRichBlockPhoto{
+						Photo: models.InputMediaPhoto{
+							Media:           "attach://photo.jpg",
+							MediaAttachment: strings.NewReader("photo content"),
+						},
+					},
+				},
+				{
+					Type: models.RichBlockTypeDetails,
+					InputRichBlockDetails: &models.InputRichBlockDetails{
+						Summary: models.RichText{PlainText: "sum"},
+						Blocks: []models.InputRichBlock{
+							{
+								Type: models.RichBlockTypeVideo,
+								InputRichBlockVideo: &models.InputRichBlockVideo{
+									Video: models.InputMediaVideo{
+										Media:           "attach://video.mp4",
+										MediaAttachment: strings.NewReader("video content"),
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Type: models.RichBlockTypeList,
+					InputRichBlockList: &models.InputRichBlockList{
+						Items: []models.InputRichBlockListItem{
+							{
+								Blocks: []models.InputRichBlock{
+									{
+										Type: models.RichBlockTypeAudio,
+										InputRichBlockAudio: &models.InputRichBlockAudio{
+											Audio: models.InputMediaAudio{
+												Media:           "attach://audio.mp3",
+												MediaAttachment: strings.NewReader("audio content"),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	buf := bytes.NewBuffer(nil)
+	form := multipart.NewWriter(buf)
+	form.SetBoundary("XXX") //nolint
+
+	fieldsCount, errBuild := buildRequestForm(form, &params)
+	if errBuild != nil {
+		t.Error(errBuild)
+		return
+	}
+	if err := form.Close(); err != nil {
+		t.Errorf("failed to close form: %v", err)
+	}
+
+	expect := `--XXX
+Content-Disposition: form-data; name="photo.jpg"; filename="photo.jpg"
+Content-Type: application/octet-stream
+
+photo content
+--XXX
+Content-Disposition: form-data; name="video.mp4"; filename="video.mp4"
+Content-Type: application/octet-stream
+
+video content
+--XXX
+Content-Disposition: form-data; name="audio.mp3"; filename="audio.mp3"
+Content-Type: application/octet-stream
+
+audio content
+--XXX
+Content-Disposition: form-data; name="rich_message"
+
+{"blocks":[{"type":"photo","photo":{"type":"photo","media":"attach://photo.jpg"}},{"type":"details","summary":"sum","blocks":[{"type":"video","video":{"type":"video","media":"attach://video.mp4"}}]},{"type":"list","items":[{"blocks":[{"type":"audio","audio":{"type":"audio","media":"attach://audio.mp3"}}]}]}]}
+--XXX--
+`
+	assertEqualInt(t, fieldsCount, 1)
+	assertFormData(t, buf.String(), expect)
+}
+
+func Test_addFormFieldInputRichMessage_nilAttachment(t *testing.T) {
+	form := multipart.NewWriter(bytes.NewBuffer(nil))
+	err := addFormFieldInputRichMessage(form, "rich_message", &models.InputRichMessage{
+		Media: []models.InputRichMessageMedia{
+			{ID: "doc1", Media: &models.InputMediaDocument{Media: "attach://doc1.pdf"}},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error for attach:// with nil MediaAttachment")
+	}
+	if !strings.Contains(err.Error(), "nil attachment") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/methods_test.go
+++ b/methods_test.go
@@ -1439,6 +1439,36 @@ func TestBot_RichMessageMethods(t *testing.T) {
 		assertNoErr(t, err)
 		assertTrue(t, resp)
 	})
+
+	t.Run("SendRichMessageWithAttachment", func(t *testing.T) {
+		c := &httpClient{
+			t:    t,
+			resp: `{"message_id":7,"date":1,"chat":{"id":123,"type":"private"}}`,
+			reqFields: map[string]string{
+				"chat_id":      "123",
+				"rich_message": `{"html":"tg://document?id=doc1","media":[{"id":"doc1","media":{"type":"document","media":"attach://doc1.pdf"}}]}`,
+			},
+			reqFiles: map[string]string{"doc1.pdf": "PDF-BYTES-HERE"},
+		}
+		b := &Bot{client: c}
+		resp, err := b.SendRichMessage(context.Background(), &SendRichMessageParams{
+			ChatID: 123,
+			RichMessage: models.InputRichMessage{
+				HTML: "tg://document?id=doc1",
+				Media: []models.InputRichMessageMedia{
+					{
+						ID: "doc1",
+						Media: &models.InputMediaDocument{
+							Media:           "attach://doc1.pdf",
+							MediaAttachment: strings.NewReader("PDF-BYTES-HERE"),
+						},
+					},
+				},
+			},
+		})
+		assertNoErr(t, err)
+		assertEqualInt(t, 7, resp.ID)
+	})
 }
 
 func TestBot_EphemeralMessageMethods(t *testing.T) {

--- a/models/input_file.go
+++ b/models/input_file.go
@@ -19,8 +19,11 @@ type InputFileUpload struct {
 
 func (*InputFileUpload) inputFileTag() {}
 
+// MarshalJSON encodes the upload as its attach:// reference, for the places the
+// value is marshalled instead of becoming a form field of its own, e.g. the
+// thumbnail of an InputMedia. Filename doubles as the name of the form part.
 func (i *InputFileUpload) MarshalJSON() ([]byte, error) {
-	return []byte(`"@` + i.Filename + `"`), nil
+	return []byte(`"attach://` + i.Filename + `"`), nil
 }
 
 type InputFileString struct {

--- a/models/input_file.go
+++ b/models/input_file.go
@@ -23,7 +23,7 @@ func (*InputFileUpload) inputFileTag() {}
 // value is marshalled instead of becoming a form field of its own, e.g. the
 // thumbnail of an InputMedia. Filename doubles as the name of the form part.
 func (i *InputFileUpload) MarshalJSON() ([]byte, error) {
-	return []byte(`"attach://` + i.Filename + `"`), nil
+	return json.Marshal("attach://" + i.Filename)
 }
 
 type InputFileString struct {
@@ -33,9 +33,25 @@ type InputFileString struct {
 func (*InputFileString) inputFileTag() {}
 
 func (i *InputFileString) MarshalJSON() ([]byte, error) {
-	return []byte(`"` + i.Data + `"`), nil
+	return json.Marshal(i.Data)
 }
 
 func (i *InputFileString) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &i.Data)
+}
+
+// normalizeInputFile turns a typed nil pointer into an untyped nil, so an omitempty
+// field carrying one is omitted instead of encoded as a null the Bot API rejects.
+func normalizeInputFile(f InputFile) InputFile {
+	switch v := f.(type) {
+	case *InputFileUpload:
+		if v == nil {
+			return nil
+		}
+	case *InputFileString:
+		if v == nil {
+			return nil
+		}
+	}
+	return f
 }

--- a/models/input_file_test.go
+++ b/models/input_file_test.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 )
@@ -14,5 +15,37 @@ func TestInputFileUpload_MarshalJSON(t *testing.T) {
 	}
 	if string(d) != `"attach://thumb.jpg"` {
 		t.Fatalf("unexpected value %s", d)
+	}
+}
+
+// The reference is a JSON string: a filename carrying a quote or a backslash must be
+// escaped, not concatenated into invalid JSON.
+func TestInputFileUpload_MarshalJSONEscapes(t *testing.T) {
+	data, err := json.Marshal(&InputFileUpload{Filename: `a"b\c.jpg`})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var got string
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got != `attach://a"b\c.jpg` {
+		t.Fatalf("unexpected reference: %s", got)
+	}
+}
+
+func TestInputFileString_MarshalJSONEscapes(t *testing.T) {
+	data, err := json.Marshal(&InputFileString{Data: `file"id`})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var got string
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got != `file"id` {
+		t.Fatalf("unexpected value: %s", got)
 	}
 }

--- a/models/input_file_test.go
+++ b/models/input_file_test.go
@@ -1,0 +1,18 @@
+package models
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestInputFileUpload_MarshalJSON(t *testing.T) {
+	// Nested in an InputMedia the value is the attach:// reference Telegram resolves
+	// against the uploaded part, not the part name itself.
+	d, err := (&InputFileUpload{Filename: "thumb.jpg", Data: strings.NewReader("x")}).MarshalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(d) != `"attach://thumb.jpg"` {
+		t.Fatalf("unexpected value %s", d)
+	}
+}

--- a/models/input_media.go
+++ b/models/input_media.go
@@ -83,6 +83,10 @@ func (m *InputMediaVideo) GetMedia() string {
 	return m.Media
 }
 
+func (m *InputMediaVideo) GetThumbnail() InputFile {
+	return m.Thumbnail
+}
+
 // inputMediaVideoAlias strips the methods of InputMediaVideo so the embedded value below is
 // encoded as plain fields instead of recursing back into MarshalJSON.
 type inputMediaVideoAlias InputMediaVideo
@@ -129,6 +133,10 @@ func (m *InputMediaAnimation) GetMedia() string {
 	return m.Media
 }
 
+func (m *InputMediaAnimation) GetThumbnail() InputFile {
+	return m.Thumbnail
+}
+
 // inputMediaAnimationAlias strips the methods of InputMediaAnimation so the embedded value below is
 // encoded as plain fields instead of recursing back into MarshalJSON.
 type inputMediaAnimationAlias InputMediaAnimation
@@ -171,6 +179,10 @@ func (m *InputMediaAudio) Attachment() io.Reader {
 
 func (m *InputMediaAudio) GetMedia() string {
 	return m.Media
+}
+
+func (m *InputMediaAudio) GetThumbnail() InputFile {
+	return m.Thumbnail
 }
 
 // inputMediaAudioAlias strips the methods of InputMediaAudio so the embedded value below is
@@ -254,6 +266,10 @@ func (m *InputMediaDocument) Attachment() io.Reader {
 
 func (m *InputMediaDocument) GetMedia() string {
 	return m.Media
+}
+
+func (m *InputMediaDocument) GetThumbnail() InputFile {
+	return m.Thumbnail
 }
 
 // inputMediaDocumentAlias strips the methods of InputMediaDocument so the embedded value below is

--- a/models/input_media.go
+++ b/models/input_media.go
@@ -92,6 +92,7 @@ func (m *InputMediaVideo) GetThumbnail() InputFile {
 type inputMediaVideoAlias InputMediaVideo
 
 func (m InputMediaVideo) MarshalInputMedia() ([]byte, error) {
+	m.Thumbnail = normalizeInputFile(m.Thumbnail)
 	return json.Marshal(struct {
 		Type string `json:"type"`
 		inputMediaVideoAlias
@@ -142,6 +143,7 @@ func (m *InputMediaAnimation) GetThumbnail() InputFile {
 type inputMediaAnimationAlias InputMediaAnimation
 
 func (m InputMediaAnimation) MarshalInputMedia() ([]byte, error) {
+	m.Thumbnail = normalizeInputFile(m.Thumbnail)
 	return json.Marshal(struct {
 		Type string `json:"type"`
 		inputMediaAnimationAlias
@@ -190,6 +192,7 @@ func (m *InputMediaAudio) GetThumbnail() InputFile {
 type inputMediaAudioAlias InputMediaAudio
 
 func (m InputMediaAudio) MarshalInputMedia() ([]byte, error) {
+	m.Thumbnail = normalizeInputFile(m.Thumbnail)
 	return json.Marshal(struct {
 		Type string `json:"type"`
 		inputMediaAudioAlias
@@ -277,6 +280,7 @@ func (m *InputMediaDocument) GetThumbnail() InputFile {
 type inputMediaDocumentAlias InputMediaDocument
 
 func (m InputMediaDocument) MarshalInputMedia() ([]byte, error) {
+	m.Thumbnail = normalizeInputFile(m.Thumbnail)
 	return json.Marshal(struct {
 		Type string `json:"type"`
 		inputMediaDocumentAlias

--- a/models/input_media_test.go
+++ b/models/input_media_test.go
@@ -30,3 +30,44 @@ func TestInputMedia_GetThumbnailNotSet(t *testing.T) {
 		t.Fatal("expected no thumbnail")
 	}
 }
+
+// A thumbnail left as a typed nil pointer is not a thumbnail: omitempty cannot see it
+// through the interface, so it has to be normalised or the request carries a null
+// where the Bot API expects a string.
+func TestInputMedia_MarshalTypedNilThumbnailOmitted(t *testing.T) {
+	var upload *InputFileUpload
+
+	tests := map[string]interface {
+		MarshalInputMedia() ([]byte, error)
+	}{
+		"video":      &InputMediaVideo{Media: "file_id", Thumbnail: upload},
+		"animation":  &InputMediaAnimation{Media: "file_id", Thumbnail: upload},
+		"audio":      &InputMediaAudio{Media: "file_id", Thumbnail: upload},
+		"document":   &InputMediaDocument{Media: "file_id", Thumbnail: upload},
+		"paid video": &InputPaidMediaVideo{Media: "file_id", Thumbnail: upload},
+	}
+
+	for name, media := range tests {
+		t.Run(name, func(t *testing.T) {
+			data, err := media.MarshalInputMedia()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if strings.Contains(string(data), "thumbnail") {
+				t.Fatalf("thumbnail not omitted: %s", data)
+			}
+		})
+	}
+}
+
+func TestInputMedia_MarshalTypedNilInputFileStringThumbnailOmitted(t *testing.T) {
+	var file *InputFileString
+
+	data, err := (&InputMediaVideo{Media: "file_id", Thumbnail: file}).MarshalInputMedia()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), "thumbnail") {
+		t.Fatalf("thumbnail not omitted: %s", data)
+	}
+}

--- a/models/input_media_test.go
+++ b/models/input_media_test.go
@@ -1,0 +1,32 @@
+package models
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestInputMedia_GetThumbnail(t *testing.T) {
+	thumb := &InputFileUpload{Filename: "thumb.jpg", Data: strings.NewReader("thumb")}
+
+	media := []interface {
+		GetThumbnail() InputFile
+	}{
+		&InputMediaVideo{Thumbnail: thumb},
+		&InputMediaAnimation{Thumbnail: thumb},
+		&InputMediaAudio{Thumbnail: thumb},
+		&InputMediaDocument{Thumbnail: thumb},
+		&InputPaidMediaVideo{Thumbnail: thumb},
+	}
+
+	for _, m := range media {
+		if m.GetThumbnail() != InputFile(thumb) {
+			t.Fatalf("%T returned another thumbnail", m)
+		}
+	}
+}
+
+func TestInputMedia_GetThumbnailNotSet(t *testing.T) {
+	if (&InputMediaVideo{}).GetThumbnail() != nil {
+		t.Fatal("expected no thumbnail")
+	}
+}

--- a/models/paid.go
+++ b/models/paid.go
@@ -72,12 +72,15 @@ func (m *InputPaidMediaVideo) GetThumbnail() InputFile {
 }
 
 func (m *InputPaidMediaVideo) MarshalInputMedia() ([]byte, error) {
+	normalized := *m
+	normalized.Thumbnail = normalizeInputFile(normalized.Thumbnail)
+
 	ret := struct {
 		Type string `json:"type"`
 		*InputPaidMediaVideo
 	}{
 		Type:                "video",
-		InputPaidMediaVideo: m,
+		InputPaidMediaVideo: &normalized,
 	}
 
 	return json.Marshal(&ret)

--- a/models/paid.go
+++ b/models/paid.go
@@ -67,6 +67,10 @@ func (m *InputPaidMediaVideo) GetMedia() string {
 	return m.Media
 }
 
+func (m *InputPaidMediaVideo) GetThumbnail() InputFile {
+	return m.Thumbnail
+}
+
 func (m *InputPaidMediaVideo) MarshalInputMedia() ([]byte, error) {
 	ret := struct {
 		Type string `json:"type"`


### PR DESCRIPTION
Fixes #298, and a second attachment bug in the same code path that surfaced while fixing it.

1. Attachments nested in a rich message are never uploaded (#298)

buildRequestForm had no case for models.InputRichMessage, so the field fell through to addFormFieldDefault and was written with a plain json.Marshal. The attach:// references were serialized into the JSON, but no file part was ever created, so Telegram had nothing to resolve them against and the readers were never read.

The attach:// walking that addFormFieldInputMediaItem and addFormFieldInputMediaSlice do for top level InputMedia fields simply never reached anything nested inside a rich message.

Fixed by adding addFormFieldInputRichMessage, which uploads the referenced attachments before encoding the field:

- InputRichMessage.Media[].Media
- the media blocks: InputRichBlockAnimation, InputRichBlockAudio, InputRichBlockDocument, InputRichBlockPhoto, InputRichBlockVideo, InputRichBlockVoiceNote
- recursively through the container blocks that carry nested blocks: InputRichBlockList (per item), InputRichBlockBlockQuotation, InputRichBlockCollage, InputRichBlockSlideshow, InputRichBlockDetails

Wired into the type switch for both shapes the params use: models.InputRichMessage (sendRichMessage, sendRichMessageDraft) and *models.InputRichMessage (editMessageText, editEphemeralMessageText).

The upload half of addFormFieldInputMediaItem is extracted into addInputMediaAttachment so the walker reuses it instead of duplicating the attach:// handling. The encoding of the field itself is unchanged.

2. The thumbnail of an InputMedia is never uploaded

Same class of bug, found by tracing the rest of the attach:// handling.

InputFileUpload.MarshalJSON emitted "@<filename>", which is not a Bot API reference. At the top level of a request this never showed: a Thumbnail field there becomes its own form part named thumbnail and the marshalled value is not used. Nested inside an InputMedia, the marshalled value is what Telegram reads, so the thumbnail was broken twice over: an unusable reference, and no file part to point at.

Affects InputMediaVideo, InputMediaAnimation, InputMediaAudio, InputMediaDocument and InputPaidMediaVideo, and therefore sendMediaGroup, editMessageMedia, editEphemeralMessageMedia, sendPaidMedia and the media blocks of a rich message.

Fixed by:

- InputFileUpload.MarshalJSON now emits attach://<filename>, the reference Telegram actually resolves, with Filename doubling as the part name
- a GetThumbnail() accessor on the five types that carry one, alongside the existing GetMedia() and Attachment()
- addInputFileAttachment, called from addInputMediaAttachment, which uploads a nested *InputFileUpload and leaves an InputFileString (a file_id or an URL) to the encoder

A nil Data on a nested upload returns an error rather than panicking, matching the treatment of nil MediaAttachment from #296.

Compatibility

No API is removed or renamed. Two behaviour changes worth naming:

- InputFileUpload.MarshalJSON returns a different string. Nothing consumed the old "@<filename>" form, since Telegram rejects it; the only other place it appears is the payload printed by the debug handler.
- The five GetThumbnail() methods are new exported methods on existing types.