### PR TITLE
fix: tolerate unknown polymorphic types and skip undecodable updates in getUpdates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## v1.26.0
+
+- Fix: an unknown polymorphic discriminator no longer stalls long polling. Fourteen
+  models (`ChatMember`, `ReactionType`, `ChatBoostSource`, `OwnedGift`, `MenuButton`,
+  `MessageOrigin`, `StoryAreaType`, `TransactionPartner`, `RevenueWithdrawalState`,
+  `BackgroundType`, `BackgroundFill`, `RichBlock`, `RichText`, `PaidMedia`) returned
+  `unsupported <Type> type` from `UnmarshalJSON` when the `type` / `status` / `source`
+  value was not in their switch. `getUpdates` decoded the whole batch with one
+  `json.Unmarshal`, so a single update carrying a value added by a Bot API release
+  failed the entire call, the offset never advanced, and the same batch was requested
+  and rejected forever. The wrapper now keeps the raw value in `Type` (`Source` for
+  `ChatBoostSource`), leaves every variant pointer nil and returns no error, so a
+  consumer switching on `Type` reaches its default branch instead of never seeing the
+  update. The webhook path gets the same tolerance through the models.
+- Fix: `MarshalJSON` accepts what `UnmarshalJSON` accepts. An unknown discriminator is
+  encoded as the bare `{"type":"<Type>"}` (`status` / `source` where applicable)
+  instead of returning `unsupported <Type> type`, so an update that is logged,
+  persisted, queued as JSON, or echoed back into a request still round trips on the day
+  Telegram ships a new variant. Only the discriminator is written: no variant was
+  populated, so there is nothing else to encode. An empty discriminator is an unset
+  value rather than a variant from a future release and stays an error.
+- Fix: `ReactionType.MarshalJSON` handles `paid`. The variant has been decodable since
+  Bot API 7.6 but had no marshal case, so a paid reaction read from an update could not
+  be encoded back, e.g. into `setMessageReaction`.
+- Fix: `getUpdates` decodes each update on its own. An update that still fails to
+  decode is reported through the errors handler with its `update_id` and its raw
+  payload, the offset moves past it, and the rest of the batch is delivered. When the
+  `update_id` itself cannot be read the offset cannot move, so the poll backs off
+  (100ms..5s) as it does on a failed request, instead of re-requesting the same batch
+  in a tight loop.
+- Fix: a `RichText` tagged object without a `type` is rejected again. An empty `Type`
+  is RichText's plain-string form, so tolerating a missing discriminator would decode
+  `{"text":"hi"}` to an empty plain string instead of to an unknown variant.
+
 ## v1.25.0 (2026-09-01)
 
 - Fix: attachments nested in a rich message are uploaded. `buildRequestForm` had
@@ -114,7 +148,8 @@
 - Fix: `MarshalJSON` on the `InputRichBlock`, `RichBlock` and `RichText` tagged
   unions returns an error instead of panicking when `Type` is set without its
   matching variant pointer, and reports an unknown `Type` as unsupported rather
-  than as a missing variant.
+  than as a missing variant. (Since v1.26.0 an unknown `Type` is not an error on
+  either side.)
 - Fix: marshaling those unions no longer writes the discriminator back into the
   caller's variant. The `type` field is stamped on a copy, so encoding has no
   side effects and the same value can be encoded from several goroutines.

--- a/get_updates.go
+++ b/get_updates.go
@@ -2,6 +2,7 @@ package bot
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"sync"
 	"sync/atomic"
@@ -56,7 +57,7 @@ func (b *Bot) getUpdates(ctx context.Context, wg *sync.WaitGroup) {
 			params.AllowedUpdates = b.allowedUpdates
 		}
 
-		var updates []*models.Update
+		var updates []json.RawMessage
 
 		errRequest := b.rawRequest(ctx, "getUpdates", params, &updates)
 		if errRequest != nil {
@@ -77,8 +78,15 @@ func (b *Bot) getUpdates(ctx context.Context, wg *sync.WaitGroup) {
 
 		timeoutAfterError = 0
 
-		for _, upd := range updates {
-			atomic.StoreInt64(&b.lastUpdateID, upd.ID)
+		for _, raw := range updates {
+			upd, errDecode := decodeUpdate(raw)
+			if upd.ID != 0 {
+				atomic.StoreInt64(&b.lastUpdateID, upd.ID)
+			}
+			if errDecode != nil {
+				b.error("error decode update %d, skipped, %w", upd.ID, errDecode)
+				continue
+			}
 			select {
 			case <-ctx.Done():
 				b.error("some updates lost, ctx done")
@@ -87,6 +95,23 @@ func (b *Bot) getUpdates(ctx context.Context, wg *sync.WaitGroup) {
 			}
 		}
 	}
+}
+
+// decodeUpdate decodes one update on its own, so a single undecodable update does not
+// reject the whole batch. On failure the id is still read, so the offset moves past it.
+func decodeUpdate(raw json.RawMessage) (*models.Update, error) {
+	upd := &models.Update{}
+	errDecode := json.Unmarshal(raw, upd)
+	if errDecode == nil {
+		return upd, nil
+	}
+
+	head := struct {
+		ID int64 `json:"update_id"`
+	}{}
+	_ = json.Unmarshal(raw, &head)
+
+	return &models.Update{ID: head.ID}, errDecode
 }
 
 func incErrTimeout(timeout time.Duration) time.Duration {

--- a/get_updates.go
+++ b/get_updates.go
@@ -80,13 +80,19 @@ func (b *Bot) getUpdates(ctx context.Context, wg *sync.WaitGroup) {
 
 		for _, raw := range updates {
 			upd, errDecode := decodeUpdate(raw)
-			if upd.ID != 0 {
-				atomic.StoreInt64(&b.lastUpdateID, upd.ID)
-			}
 			if errDecode != nil {
-				b.error("error decode update %d, skipped, %w", upd.ID, errDecode)
+				b.error("error decode update %d, skipped, %s, %w", upd.ID, raw, errDecode)
+				if upd.ID == 0 {
+					// The id could not be read, so the offset cannot move past this
+					// update and the same batch comes back. Back off as on a failed
+					// request instead of re-requesting it at full speed.
+					timeoutAfterError = incErrTimeout(timeoutAfterError)
+					continue
+				}
+				atomic.StoreInt64(&b.lastUpdateID, upd.ID)
 				continue
 			}
+			atomic.StoreInt64(&b.lastUpdateID, upd.ID)
 			select {
 			case <-ctx.Done():
 				b.error("some updates lost, ctx done")

--- a/get_updates_test.go
+++ b/get_updates_test.go
@@ -1,0 +1,76 @@
+package bot
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/go-telegram/bot/models"
+)
+
+type clientFunc func(*http.Request) (*http.Response, error)
+
+func (f clientFunc) Do(req *http.Request) (*http.Response, error) {
+	// drain the multipart body so the request pipe writer can finish
+	_, _ = io.Copy(io.Discard, req.Body)
+	_ = req.Body.Close()
+	return f(req)
+}
+
+func jsonResponse(body string) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+// One undecodable update must not poison the batch: the others are delivered,
+// the offset moves past it and the failure is reported with the update id.
+func Test_getUpdates_skipsUndecodableUpdate(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	batch := `{"ok":true,"result":[
+		{"update_id":100,"message":{"message_id":1,"text":"first"}},
+		{"update_id":101,"message":"not an object"},
+		{"update_id":102,"message":{"message_id":2,"text":"third"}}
+	]}`
+
+	var calls int32
+	var errs []string
+	b := &Bot{
+		token:         "XXX",
+		updates:       make(chan *models.Update, 10),
+		errorsHandler: func(err error) { errs = append(errs, err.Error()) },
+		debugHandler:  func(string, ...any) {},
+		client: clientFunc(func(*http.Request) (*http.Response, error) {
+			if atomic.AddInt32(&calls, 1) > 1 {
+				cancel()
+				return nil, ctx.Err()
+			}
+			return jsonResponse(batch), nil
+		}),
+	}
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	b.getUpdates(ctx, &wg)
+	wg.Wait()
+
+	if got := atomic.LoadInt64(&b.lastUpdateID); got != 102 {
+		t.Fatalf("offset must move past the bad update, lastUpdateID=%d", got)
+	}
+	if len(b.updates) != 2 {
+		t.Fatalf("expected 2 delivered updates, got %d", len(b.updates))
+	}
+	if first, third := <-b.updates, <-b.updates; first.ID != 100 || third.ID != 102 {
+		t.Fatalf("expected updates 100 and 102, got %d and %d", first.ID, third.ID)
+	}
+	if len(errs) != 1 || !strings.Contains(errs[0], "101") {
+		t.Fatalf("undecodable update must be reported once with its id, got %v", errs)
+	}
+}

--- a/get_updates_test.go
+++ b/get_updates_test.go
@@ -8,20 +8,21 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/go-telegram/bot/models"
 )
 
-type clientFunc func(*http.Request) (*http.Response, error)
+type getUpdatesClientFunc func(*http.Request) (*http.Response, error)
 
-func (f clientFunc) Do(req *http.Request) (*http.Response, error) {
+func (f getUpdatesClientFunc) Do(req *http.Request) (*http.Response, error) {
 	// drain the multipart body so the request pipe writer can finish
 	_, _ = io.Copy(io.Discard, req.Body)
 	_ = req.Body.Close()
 	return f(req)
 }
 
-func jsonResponse(body string) *http.Response {
+func getUpdatesJSONResponse(body string) *http.Response {
 	return &http.Response{
 		StatusCode: http.StatusOK,
 		Body:       io.NopCloser(strings.NewReader(body)),
@@ -45,14 +46,14 @@ func Test_getUpdates_skipsUndecodableUpdate(t *testing.T) {
 	b := &Bot{
 		token:         "XXX",
 		updates:       make(chan *models.Update, 10),
-		errorsHandler: func(err error) { errs = append(errs, err.Error()) },
+		errorsHandler: func(handlerErr error) { errs = append(errs, handlerErr.Error()) },
 		debugHandler:  func(string, ...any) {},
-		client: clientFunc(func(*http.Request) (*http.Response, error) {
+		client: getUpdatesClientFunc(func(*http.Request) (*http.Response, error) {
 			if atomic.AddInt32(&calls, 1) > 1 {
 				cancel()
 				return nil, ctx.Err()
 			}
-			return jsonResponse(batch), nil
+			return getUpdatesJSONResponse(batch), nil
 		}),
 	}
 
@@ -70,7 +71,48 @@ func Test_getUpdates_skipsUndecodableUpdate(t *testing.T) {
 	if first, third := <-b.updates, <-b.updates; first.ID != 100 || third.ID != 102 {
 		t.Fatalf("expected updates 100 and 102, got %d and %d", first.ID, third.ID)
 	}
-	if len(errs) != 1 || !strings.Contains(errs[0], "101") {
-		t.Fatalf("undecodable update must be reported once with its id, got %v", errs)
+	if len(errs) != 1 || !strings.Contains(errs[0], "101") || !strings.Contains(errs[0], "not an object") {
+		t.Fatalf("undecodable update must be reported once with its id and raw payload, got %v", errs)
+	}
+}
+
+// An update whose id cannot be read leaves the offset where it is, so the very same
+// batch comes back on the next request. Without a backoff that is a tight loop.
+func Test_getUpdates_backsOffWhenUpdateIDUnreadable(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	batch := `{"ok":true,"result":[{"update_id":"abc","message":"x"}]}`
+
+	var calls int
+	var firstCallAt time.Time
+	var gap time.Duration
+
+	b := &Bot{
+		token:         "XXX",
+		updates:       make(chan *models.Update, 10),
+		errorsHandler: func(error) {},
+		debugHandler:  func(string, ...any) {},
+		client: getUpdatesClientFunc(func(*http.Request) (*http.Response, error) {
+			calls++
+			switch calls {
+			case 1:
+				firstCallAt = time.Now()
+			case 2:
+				gap = time.Since(firstCallAt)
+				cancel()
+				return nil, ctx.Err()
+			}
+			return getUpdatesJSONResponse(batch), nil
+		}),
+	}
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	b.getUpdates(ctx, &wg)
+	wg.Wait()
+
+	if gap < 100*time.Millisecond {
+		t.Fatalf("expected a backoff before the next request, got %v", gap)
 	}
 }

--- a/models/boost.go
+++ b/models/boost.go
@@ -70,7 +70,8 @@ func (cbs *ChatBoostSource) UnmarshalJSON(data []byte) error {
 		return json.Unmarshal(data, cbs.ChatBoostSourceGiveaway)
 	}
 
-	return fmt.Errorf("unsupported ChatBoostSource type")
+	cbs.Source = v.Source
+	return nil
 }
 
 func (cbs *ChatBoostSource) MarshalJSON() ([]byte, error) {

--- a/models/boost.go
+++ b/models/boost.go
@@ -2,7 +2,6 @@ package models
 
 import (
 	"encoding/json"
-	"fmt"
 )
 
 // ChatBoostAdded https://core.telegram.org/bots/api#chatboostadded
@@ -55,22 +54,20 @@ func (cbs *ChatBoostSource) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	cbs.Source = v.Source
+
 	switch v.Source {
 	case ChatBoostSourceTypePremium:
-		cbs.Source = ChatBoostSourceTypePremium
 		cbs.ChatBoostSourcePremium = &ChatBoostSourcePremium{}
 		return json.Unmarshal(data, cbs.ChatBoostSourcePremium)
 	case ChatBoostSourceTypeGiftCode:
-		cbs.Source = ChatBoostSourceTypeGiftCode
 		cbs.ChatBoostSourceGiftCode = &ChatBoostSourceGiftCode{}
 		return json.Unmarshal(data, cbs.ChatBoostSourceGiftCode)
 	case ChatBoostSourceTypeGiveaway:
-		cbs.Source = ChatBoostSourceTypeGiveaway
 		cbs.ChatBoostSourceGiveaway = &ChatBoostSourceGiveaway{}
 		return json.Unmarshal(data, cbs.ChatBoostSourceGiveaway)
 	}
 
-	cbs.Source = v.Source
 	return nil
 }
 
@@ -87,7 +84,7 @@ func (cbs *ChatBoostSource) MarshalJSON() ([]byte, error) {
 		return json.Marshal(cbs.ChatBoostSourceGiveaway)
 	}
 
-	return nil, fmt.Errorf("unsupported ChatBoostSource type")
+	return marshalUnknownVariant("ChatBoostSource", "source", cbs.Source)
 }
 
 // ChatBoostSourceType https://core.telegram.org/bots/api#chatboostsource

--- a/models/chat_background.go
+++ b/models/chat_background.go
@@ -52,7 +52,8 @@ func (cb *BackgroundType) UnmarshalJSON(data []byte) error {
 		return json.Unmarshal(data, &cb.Theme)
 	}
 
-	return fmt.Errorf("unsupported ChatBackground type")
+	cb.Type = v.Type
+	return nil
 }
 
 func (cb *BackgroundType) MarshalJSON() ([]byte, error) {
@@ -144,7 +145,8 @@ func (bf *BackgroundFill) UnmarshalJSON(data []byte) error {
 		return json.Unmarshal(data, bf.FreeformGradient)
 	}
 
-	return fmt.Errorf("unsupported BackgroundFill type")
+	bf.Type = v.Type
+	return nil
 }
 
 func (bf *BackgroundFill) MarshalJSON() ([]byte, error) {

--- a/models/chat_background.go
+++ b/models/chat_background.go
@@ -2,7 +2,6 @@ package models
 
 import (
 	"encoding/json"
-	"fmt"
 )
 
 type BackgroundTypeType string
@@ -37,22 +36,19 @@ func (cb *BackgroundType) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	cb.Type = v.Type
+
 	switch v.Type {
 	case ChatBackgroundTypeFill:
-		cb.Type = ChatBackgroundTypeFill
 		return json.Unmarshal(data, &cb.Fill)
 	case ChatBackgroundTypeWallpaper:
-		cb.Type = ChatBackgroundTypeWallpaper
 		return json.Unmarshal(data, &cb.Wallpaper)
 	case ChatBackgroundTypePattern:
-		cb.Type = ChatBackgroundTypePattern
 		return json.Unmarshal(data, &cb.Pattern)
 	case ChatBackgroundTypeChatTheme:
-		cb.Type = ChatBackgroundTypeChatTheme
 		return json.Unmarshal(data, &cb.Theme)
 	}
 
-	cb.Type = v.Type
 	return nil
 }
 
@@ -72,7 +68,7 @@ func (cb *BackgroundType) MarshalJSON() ([]byte, error) {
 		return json.Marshal(cb.Theme)
 	}
 
-	return nil, fmt.Errorf("unsupported ChatBackground type")
+	return marshalUnknownVariant("BackgroundType", "type", cb.Type)
 }
 
 // BackgroundTypeFill https://core.telegram.org/bots/api#backgroundtypefill
@@ -130,22 +126,20 @@ func (bf *BackgroundFill) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	bf.Type = v.Type
+
 	switch v.Type {
 	case BackgroundFillTypeSolid:
-		bf.Type = BackgroundFillTypeSolid
 		bf.Solid = &BackgroundFillSolid{}
 		return json.Unmarshal(data, bf.Solid)
 	case BackgroundFillTypeGradient:
-		bf.Type = BackgroundFillTypeGradient
 		bf.Gradient = &BackgroundFillGradient{}
 		return json.Unmarshal(data, bf.Gradient)
 	case BackgroundFillTypeFreeformGradient:
-		bf.Type = BackgroundFillTypeFreeformGradient
 		bf.FreeformGradient = &BackgroundFillFreeformGradient{}
 		return json.Unmarshal(data, bf.FreeformGradient)
 	}
 
-	bf.Type = v.Type
 	return nil
 }
 
@@ -162,7 +156,7 @@ func (bf *BackgroundFill) MarshalJSON() ([]byte, error) {
 		return json.Marshal(bf.FreeformGradient)
 	}
 
-	return nil, fmt.Errorf("unsupported BackgroundFill type")
+	return marshalUnknownVariant("BackgroundFill", "type", bf.Type)
 }
 
 // BackgroundFillSolid https://core.telegram.org/bots/api#backgroundfillsolid

--- a/models/chat_member.go
+++ b/models/chat_member.go
@@ -75,7 +75,8 @@ func (c *ChatMember) UnmarshalJSON(data []byte) error {
 		return json.Unmarshal(data, c.Banned)
 	}
 
-	return fmt.Errorf("unsupported ChatMember type")
+	c.Type = v.Status
+	return nil
 }
 
 func (c *ChatMember) MarshalJSON() ([]byte, error) {

--- a/models/chat_member.go
+++ b/models/chat_member.go
@@ -2,7 +2,6 @@ package models
 
 import (
 	"encoding/json"
-	"fmt"
 )
 
 // ChatMemberUpdated https://core.telegram.org/bots/api#chatmemberupdated
@@ -48,34 +47,29 @@ func (c *ChatMember) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	c.Type = v.Status
+
 	switch v.Status {
 	case ChatMemberTypeOwner:
-		c.Type = ChatMemberTypeOwner
 		c.Owner = &ChatMemberOwner{}
 		return json.Unmarshal(data, c.Owner)
 	case ChatMemberTypeAdministrator:
-		c.Type = ChatMemberTypeAdministrator
 		c.Administrator = &ChatMemberAdministrator{}
 		return json.Unmarshal(data, c.Administrator)
 	case ChatMemberTypeMember:
-		c.Type = ChatMemberTypeMember
 		c.Member = &ChatMemberMember{}
 		return json.Unmarshal(data, c.Member)
 	case ChatMemberTypeRestricted:
-		c.Type = ChatMemberTypeRestricted
 		c.Restricted = &ChatMemberRestricted{}
 		return json.Unmarshal(data, c.Restricted)
 	case ChatMemberTypeLeft:
-		c.Type = ChatMemberTypeLeft
 		c.Left = &ChatMemberLeft{}
 		return json.Unmarshal(data, c.Left)
 	case ChatMemberTypeBanned:
-		c.Type = ChatMemberTypeBanned
 		c.Banned = &ChatMemberBanned{}
 		return json.Unmarshal(data, c.Banned)
 	}
 
-	c.Type = v.Status
 	return nil
 }
 
@@ -101,7 +95,7 @@ func (c *ChatMember) MarshalJSON() ([]byte, error) {
 		return json.Marshal(c.Banned)
 	}
 
-	return nil, fmt.Errorf("unsupported ChatMember type")
+	return marshalUnknownVariant("ChatMember", "status", c.Type)
 }
 
 // ChatMemberOwner https://core.telegram.org/bots/api#chatmemberowner

--- a/models/gift.go
+++ b/models/gift.go
@@ -2,7 +2,6 @@ package models
 
 import (
 	"encoding/json"
-	"fmt"
 )
 
 // Gifts https://core.telegram.org/bots/api#gifts
@@ -73,7 +72,8 @@ func (g *OwnedGift) UnmarshalJSON(data []byte) error {
 		return json.Unmarshal(data, g.OwnedGiftUnique)
 	}
 
-	return fmt.Errorf("unsupported OwnedGift type")
+	g.Type = v.Type
+	return nil
 }
 
 // OwnedGiftType https://core.telegram.org/bots/api#ownedgift

--- a/models/gift.go
+++ b/models/gift.go
@@ -57,22 +57,21 @@ func (g *OwnedGift) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	g.Type = v.Type
+
 	switch v.Type {
 	case OwnedGiftTypeRegular:
-		g.Type = OwnedGiftTypeRegular
 		g.OwnedGiftRegular = &OwnedGiftRegular{
 			Type: OwnedGiftTypeRegular,
 		}
 		return json.Unmarshal(data, g.OwnedGiftRegular)
 	case OwnedGiftTypeUnique:
-		g.Type = OwnedGiftTypeUnique
 		g.OwnedGiftUnique = &OwnedGiftUnique{
 			Type: OwnedGiftTypeUnique,
 		}
 		return json.Unmarshal(data, g.OwnedGiftUnique)
 	}
 
-	g.Type = v.Type
 	return nil
 }
 

--- a/models/menu_button.go
+++ b/models/menu_button.go
@@ -49,7 +49,8 @@ func (c *MenuButton) UnmarshalJSON(data []byte) error {
 		return json.Unmarshal(data, c.Default)
 	}
 
-	return fmt.Errorf("unsupported MenuButton type")
+	c.Type = v.Type
+	return nil
 }
 
 func (c *MenuButton) MarshalJSON() ([]byte, error) {

--- a/models/menu_button.go
+++ b/models/menu_button.go
@@ -2,7 +2,6 @@ package models
 
 import (
 	"encoding/json"
-	"fmt"
 )
 
 type MenuButtonType string
@@ -34,22 +33,20 @@ func (c *MenuButton) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	c.Type = v.Type
+
 	switch v.Type {
 	case MenuButtonTypeCommands:
-		c.Type = MenuButtonTypeCommands
 		c.Commands = &MenuButtonCommands{}
 		return json.Unmarshal(data, c.Commands)
 	case MenuButtonTypeWebApp:
-		c.Type = MenuButtonTypeWebApp
 		c.WebApp = &MenuButtonWebApp{}
 		return json.Unmarshal(data, c.WebApp)
 	case MenuButtonTypeDefault:
-		c.Type = MenuButtonTypeDefault
 		c.Default = &MenuButtonDefault{}
 		return json.Unmarshal(data, c.Default)
 	}
 
-	c.Type = v.Type
 	return nil
 }
 
@@ -66,7 +63,7 @@ func (c *MenuButton) MarshalJSON() ([]byte, error) {
 		return json.Marshal(c.Default)
 	}
 
-	return nil, fmt.Errorf("unsupported MenuButton type")
+	return marshalUnknownVariant("MenuButton", "type", c.Type)
 }
 
 // MenuButtonCommands https://core.telegram.org/bots/api#menubuttoncommands

--- a/models/paid.go
+++ b/models/paid.go
@@ -2,7 +2,6 @@ package models
 
 import (
 	"encoding/json"
-	"fmt"
 	"io"
 )
 
@@ -124,9 +123,9 @@ func (p *PaidMedia) UnmarshalJSON(data []byte) error {
 	case PaidMediaTypeVideo:
 		p.Video = &PaidMediaVideo{}
 		return json.Unmarshal(data, p.Video)
-	default:
-		return fmt.Errorf("unsupported PaidMedia type, %v", v.Type)
 	}
+
+	return nil
 }
 
 // PaidMediaPreview https://core.telegram.org/bots/api#paidmediapreview

--- a/models/reaction.go
+++ b/models/reaction.go
@@ -60,7 +60,8 @@ func (rt *ReactionType) UnmarshalJSON(data []byte) error {
 		return json.Unmarshal(data, rt.ReactionTypePaid)
 	}
 
-	return fmt.Errorf("unsupported ReactionType type")
+	rt.Type = ReactionTypeType(v.Type)
+	return nil
 }
 
 // ReactionTypeEmoji https://core.telegram.org/bots/api#reactiontypeemoji

--- a/models/reaction.go
+++ b/models/reaction.go
@@ -2,7 +2,6 @@ package models
 
 import (
 	"encoding/json"
-	"fmt"
 )
 
 // ReactionTypeType https://core.telegram.org/bots/api#reactiontype
@@ -31,36 +30,37 @@ func (rt *ReactionType) MarshalJSON() ([]byte, error) {
 	case ReactionTypeTypeCustomEmoji:
 		rt.ReactionTypeCustomEmoji.Type = ReactionTypeTypeCustomEmoji
 		return json.Marshal(rt.ReactionTypeCustomEmoji)
+	case ReactionTypeTypePaid:
+		rt.ReactionTypePaid.Type = string(ReactionTypeTypePaid)
+		return json.Marshal(rt.ReactionTypePaid)
 	}
 
-	return nil, fmt.Errorf("unsupported ReactionType type")
+	return marshalUnknownVariant("ReactionType", "type", rt.Type)
 }
 
 func (rt *ReactionType) UnmarshalJSON(data []byte) error {
 	v := struct {
-		Type string `json:"type"`
+		Type ReactionTypeType `json:"type"`
 	}{}
 	err := json.Unmarshal(data, &v)
 	if err != nil {
 		return err
 	}
 
+	rt.Type = v.Type
+
 	switch v.Type {
-	case "emoji":
-		rt.Type = ReactionTypeTypeEmoji
+	case ReactionTypeTypeEmoji:
 		rt.ReactionTypeEmoji = &ReactionTypeEmoji{}
 		return json.Unmarshal(data, rt.ReactionTypeEmoji)
-	case "custom_emoji":
-		rt.Type = ReactionTypeTypeCustomEmoji
+	case ReactionTypeTypeCustomEmoji:
 		rt.ReactionTypeCustomEmoji = &ReactionTypeCustomEmoji{}
 		return json.Unmarshal(data, rt.ReactionTypeCustomEmoji)
-	case "paid":
-		rt.Type = ReactionTypeTypePaid
+	case ReactionTypeTypePaid:
 		rt.ReactionTypePaid = &ReactionTypePaid{}
 		return json.Unmarshal(data, rt.ReactionTypePaid)
 	}
 
-	rt.Type = ReactionTypeType(v.Type)
 	return nil
 }
 

--- a/models/reply.go
+++ b/models/reply.go
@@ -104,7 +104,8 @@ func (mo *MessageOrigin) UnmarshalJSON(data []byte) error {
 		return json.Unmarshal(data, mo.MessageOriginChannel)
 	}
 
-	return fmt.Errorf("unsupported MessageOrigin type")
+	mo.Type = v.Type
+	return nil
 }
 
 func (mo *MessageOrigin) MarshalJSON() ([]byte, error) {

--- a/models/reply.go
+++ b/models/reply.go
@@ -2,7 +2,6 @@ package models
 
 import (
 	"encoding/json"
-	"fmt"
 )
 
 // TextQuote https://core.telegram.org/bots/api#textquote
@@ -85,26 +84,23 @@ func (mo *MessageOrigin) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	mo.Type = v.Type
+
 	switch v.Type {
 	case MessageOriginTypeUser:
-		mo.Type = MessageOriginTypeUser
 		mo.MessageOriginUser = &MessageOriginUser{}
 		return json.Unmarshal(data, mo.MessageOriginUser)
 	case MessageOriginTypeHiddenUser:
-		mo.Type = MessageOriginTypeHiddenUser
 		mo.MessageOriginHiddenUser = &MessageOriginHiddenUser{}
 		return json.Unmarshal(data, mo.MessageOriginHiddenUser)
 	case MessageOriginTypeChat:
-		mo.Type = MessageOriginTypeChat
 		mo.MessageOriginChat = &MessageOriginChat{}
 		return json.Unmarshal(data, mo.MessageOriginChat)
 	case MessageOriginTypeChannel:
-		mo.Type = MessageOriginTypeChannel
 		mo.MessageOriginChannel = &MessageOriginChannel{}
 		return json.Unmarshal(data, mo.MessageOriginChannel)
 	}
 
-	mo.Type = v.Type
 	return nil
 }
 
@@ -124,7 +120,7 @@ func (mo *MessageOrigin) MarshalJSON() ([]byte, error) {
 		return json.Marshal(mo.MessageOriginChannel)
 	}
 
-	return nil, fmt.Errorf("unsupported MessageOrigin type")
+	return marshalUnknownVariant("MessageOrigin", "type", mo.Type)
 }
 
 // MessageOriginUser https://core.telegram.org/bots/api#messageoriginuser

--- a/models/rich_block.go
+++ b/models/rich_block.go
@@ -232,7 +232,8 @@ func (rb *RichBlock) UnmarshalJSON(data []byte) error {
 		return json.Unmarshal(data, rb.RichBlockThinking)
 	}
 
-	return fmt.Errorf("unsupported RichBlock type %q", v.Type)
+	rb.Type = v.Type
+	return nil
 }
 
 // RichBlockParagraph https://core.telegram.org/bots/api#richblockparagraph

--- a/models/rich_block.go
+++ b/models/rich_block.go
@@ -2,7 +2,6 @@ package models
 
 import (
 	"encoding/json"
-	"fmt"
 )
 
 // RichBlockType https://core.telegram.org/bots/api#richblock
@@ -122,7 +121,7 @@ func (rb RichBlock) MarshalJSON() ([]byte, error) {
 		return marshalVariant("RichBlock", rb.Type, rb.RichBlockThinking, func(v *RichBlockThinking) { v.Type = rb.Type })
 	}
 
-	return nil, fmt.Errorf("unsupported RichBlock type %q", rb.Type)
+	return marshalUnknownVariant("RichBlock", "type", rb.Type)
 }
 
 func (rb *RichBlock) UnmarshalJSON(data []byte) error {
@@ -133,106 +132,83 @@ func (rb *RichBlock) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	rb.Type = v.Type
+
 	switch v.Type {
 	case RichBlockTypeParagraph:
-		rb.Type = RichBlockTypeParagraph
 		rb.RichBlockParagraph = &RichBlockParagraph{}
 		return json.Unmarshal(data, rb.RichBlockParagraph)
 	case RichBlockTypeSectionHeading:
-		rb.Type = RichBlockTypeSectionHeading
 		rb.RichBlockSectionHeading = &RichBlockSectionHeading{}
 		return json.Unmarshal(data, rb.RichBlockSectionHeading)
 	case RichBlockTypePreformatted:
-		rb.Type = RichBlockTypePreformatted
 		rb.RichBlockPreformatted = &RichBlockPreformatted{}
 		return json.Unmarshal(data, rb.RichBlockPreformatted)
 	case RichBlockTypeFooter:
-		rb.Type = RichBlockTypeFooter
 		rb.RichBlockFooter = &RichBlockFooter{}
 		return json.Unmarshal(data, rb.RichBlockFooter)
 	case RichBlockTypeDivider:
-		rb.Type = RichBlockTypeDivider
 		rb.RichBlockDivider = &RichBlockDivider{}
 		return json.Unmarshal(data, rb.RichBlockDivider)
 	case RichBlockTypeMathematicalExpression:
-		rb.Type = RichBlockTypeMathematicalExpression
 		rb.RichBlockMathematicalExpression = &RichBlockMathematicalExpression{}
 		return json.Unmarshal(data, rb.RichBlockMathematicalExpression)
 	case RichBlockTypeAnchor:
-		rb.Type = RichBlockTypeAnchor
 		rb.RichBlockAnchor = &RichBlockAnchor{}
 		return json.Unmarshal(data, rb.RichBlockAnchor)
 	case RichBlockTypeList:
-		rb.Type = RichBlockTypeList
 		rb.RichBlockList = &RichBlockList{}
 		return json.Unmarshal(data, rb.RichBlockList)
 	case RichBlockTypeBlockQuotation:
-		rb.Type = RichBlockTypeBlockQuotation
 		rb.RichBlockBlockQuotation = &RichBlockBlockQuotation{}
 		return json.Unmarshal(data, rb.RichBlockBlockQuotation)
 	case RichBlockTypeExpandableBlockQuotation:
-		rb.Type = RichBlockTypeExpandableBlockQuotation
 		rb.RichBlockExpandableBlockQuotation = &RichBlockExpandableBlockQuotation{}
 		return json.Unmarshal(data, rb.RichBlockExpandableBlockQuotation)
 	case RichBlockTypePullQuotation:
-		rb.Type = RichBlockTypePullQuotation
 		rb.RichBlockPullQuotation = &RichBlockPullQuotation{}
 		return json.Unmarshal(data, rb.RichBlockPullQuotation)
 	case RichBlockTypeCollage:
-		rb.Type = RichBlockTypeCollage
 		rb.RichBlockCollage = &RichBlockCollage{}
 		return json.Unmarshal(data, rb.RichBlockCollage)
 	case RichBlockTypeSlideshow:
-		rb.Type = RichBlockTypeSlideshow
 		rb.RichBlockSlideshow = &RichBlockSlideshow{}
 		return json.Unmarshal(data, rb.RichBlockSlideshow)
 	case RichBlockTypeTable:
-		rb.Type = RichBlockTypeTable
 		rb.RichBlockTable = &RichBlockTable{}
 		return json.Unmarshal(data, rb.RichBlockTable)
 	case RichBlockTypeDetails:
-		rb.Type = RichBlockTypeDetails
 		rb.RichBlockDetails = &RichBlockDetails{}
 		return json.Unmarshal(data, rb.RichBlockDetails)
 	case RichBlockTypeMap:
-		rb.Type = RichBlockTypeMap
 		rb.RichBlockMap = &RichBlockMap{}
 		return json.Unmarshal(data, rb.RichBlockMap)
 	case RichBlockTypeButtons:
-		rb.Type = RichBlockTypeButtons
 		rb.RichBlockButtons = &RichBlockButtons{}
 		return json.Unmarshal(data, rb.RichBlockButtons)
 	case RichBlockTypeAnimation:
-		rb.Type = RichBlockTypeAnimation
 		rb.RichBlockAnimation = &RichBlockAnimation{}
 		return json.Unmarshal(data, rb.RichBlockAnimation)
 	case RichBlockTypeAudio:
-		rb.Type = RichBlockTypeAudio
 		rb.RichBlockAudio = &RichBlockAudio{}
 		return json.Unmarshal(data, rb.RichBlockAudio)
 	case RichBlockTypeDocument:
-		rb.Type = RichBlockTypeDocument
 		rb.RichBlockDocument = &RichBlockDocument{}
 		return json.Unmarshal(data, rb.RichBlockDocument)
 	case RichBlockTypePhoto:
-		rb.Type = RichBlockTypePhoto
 		rb.RichBlockPhoto = &RichBlockPhoto{}
 		return json.Unmarshal(data, rb.RichBlockPhoto)
 	case RichBlockTypeVideo:
-		rb.Type = RichBlockTypeVideo
 		rb.RichBlockVideo = &RichBlockVideo{}
 		return json.Unmarshal(data, rb.RichBlockVideo)
 	case RichBlockTypeVoiceNote:
-		rb.Type = RichBlockTypeVoiceNote
 		rb.RichBlockVoiceNote = &RichBlockVoiceNote{}
 		return json.Unmarshal(data, rb.RichBlockVoiceNote)
 	case RichBlockTypeThinking:
-		rb.Type = RichBlockTypeThinking
 		rb.RichBlockThinking = &RichBlockThinking{}
 		return json.Unmarshal(data, rb.RichBlockThinking)
 	}
 
-	rb.Type = v.Type
 	return nil
 }
 

--- a/models/rich_block_test.go
+++ b/models/rich_block_test.go
@@ -62,13 +62,6 @@ func TestRichBlock_BlockQuotationWithBlocks(t *testing.T) {
 	richBlockRoundTrip(t, `{"type":"blockquote","blocks":[{"type":"paragraph","text":"quoted"}]}`)
 }
 
-func TestRichBlock_UnknownType(t *testing.T) {
-	var rb RichBlock
-	if err := json.Unmarshal([]byte(`{"type":"not_a_block"}`), &rb); err == nil {
-		t.Fatal("expected error for unknown RichBlock type")
-	}
-}
-
 func TestRichMessage_RoundTrip(t *testing.T) {
 	src := `{"blocks":[{"type":"thinking","text":"hmm"},{"type":"paragraph","text":"answer"}]}`
 

--- a/models/rich_text.go
+++ b/models/rich_text.go
@@ -278,7 +278,8 @@ func (rt *RichText) UnmarshalJSON(data []byte) error {
 		return json.Unmarshal(trimmed, rt.RichTextReferenceLink)
 	}
 
-	return fmt.Errorf("unsupported RichText type %q", v.Type)
+	rt.Type = v.Type
+	return nil
 }
 
 // RichTextBold https://core.telegram.org/bots/api#richtextbold

--- a/models/rich_text.go
+++ b/models/rich_text.go
@@ -142,7 +142,7 @@ func (rt RichText) MarshalJSON() ([]byte, error) {
 		return marshalVariant("RichText", rt.Type, rt.RichTextReferenceLink, func(v *RichTextReferenceLink) { v.Type = rt.Type })
 	}
 
-	return nil, fmt.Errorf("unsupported RichText type %q", rt.Type)
+	return marshalUnknownVariant("RichText", "type", rt.Type)
 }
 
 func (rt *RichText) UnmarshalJSON(data []byte) error {
@@ -171,114 +171,96 @@ func (rt *RichText) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// An empty Type is the plain-string form. A tagged object without a "type" would
+	// alias to it and re-encode as "", so it stays an error rather than a tolerated
+	// unknown variant.
+	if v.Type == "" {
+		return fmt.Errorf("unsupported RichText type %q", v.Type)
+	}
+
+	rt.Type = v.Type
+
 	switch v.Type {
 	case RichTextTypeBold:
-		rt.Type = RichTextTypeBold
 		rt.RichTextBold = &RichTextBold{}
 		return json.Unmarshal(trimmed, rt.RichTextBold)
 	case RichTextTypeItalic:
-		rt.Type = RichTextTypeItalic
 		rt.RichTextItalic = &RichTextItalic{}
 		return json.Unmarshal(trimmed, rt.RichTextItalic)
 	case RichTextTypeUnderline:
-		rt.Type = RichTextTypeUnderline
 		rt.RichTextUnderline = &RichTextUnderline{}
 		return json.Unmarshal(trimmed, rt.RichTextUnderline)
 	case RichTextTypeStrikethrough:
-		rt.Type = RichTextTypeStrikethrough
 		rt.RichTextStrikethrough = &RichTextStrikethrough{}
 		return json.Unmarshal(trimmed, rt.RichTextStrikethrough)
 	case RichTextTypeSpoiler:
-		rt.Type = RichTextTypeSpoiler
 		rt.RichTextSpoiler = &RichTextSpoiler{}
 		return json.Unmarshal(trimmed, rt.RichTextSpoiler)
 	case RichTextTypeDateTime:
-		rt.Type = RichTextTypeDateTime
 		rt.RichTextDateTime = &RichTextDateTime{}
 		return json.Unmarshal(trimmed, rt.RichTextDateTime)
 	case RichTextTypeTextMention:
-		rt.Type = RichTextTypeTextMention
 		rt.RichTextTextMention = &RichTextTextMention{}
 		return json.Unmarshal(trimmed, rt.RichTextTextMention)
 	case RichTextTypeSubscript:
-		rt.Type = RichTextTypeSubscript
 		rt.RichTextSubscript = &RichTextSubscript{}
 		return json.Unmarshal(trimmed, rt.RichTextSubscript)
 	case RichTextTypeSuperscript:
-		rt.Type = RichTextTypeSuperscript
 		rt.RichTextSuperscript = &RichTextSuperscript{}
 		return json.Unmarshal(trimmed, rt.RichTextSuperscript)
 	case RichTextTypeMarked:
-		rt.Type = RichTextTypeMarked
 		rt.RichTextMarked = &RichTextMarked{}
 		return json.Unmarshal(trimmed, rt.RichTextMarked)
 	case RichTextTypeCode:
-		rt.Type = RichTextTypeCode
 		rt.RichTextCode = &RichTextCode{}
 		return json.Unmarshal(trimmed, rt.RichTextCode)
 	case RichTextTypeCustomEmoji:
-		rt.Type = RichTextTypeCustomEmoji
 		rt.RichTextCustomEmoji = &RichTextCustomEmoji{}
 		return json.Unmarshal(trimmed, rt.RichTextCustomEmoji)
 	case RichTextTypeMathematicalExpression:
-		rt.Type = RichTextTypeMathematicalExpression
 		rt.RichTextMathematicalExpression = &RichTextMathematicalExpression{}
 		return json.Unmarshal(trimmed, rt.RichTextMathematicalExpression)
 	case RichTextTypeURL:
-		rt.Type = RichTextTypeURL
 		rt.RichTextURL = &RichTextURL{}
 		return json.Unmarshal(trimmed, rt.RichTextURL)
 	case RichTextTypeEmailAddress:
-		rt.Type = RichTextTypeEmailAddress
 		rt.RichTextEmailAddress = &RichTextEmailAddress{}
 		return json.Unmarshal(trimmed, rt.RichTextEmailAddress)
 	case RichTextTypePhoneNumber:
-		rt.Type = RichTextTypePhoneNumber
 		rt.RichTextPhoneNumber = &RichTextPhoneNumber{}
 		return json.Unmarshal(trimmed, rt.RichTextPhoneNumber)
 	case RichTextTypeBankCardNumber:
-		rt.Type = RichTextTypeBankCardNumber
 		rt.RichTextBankCardNumber = &RichTextBankCardNumber{}
 		return json.Unmarshal(trimmed, rt.RichTextBankCardNumber)
 	case RichTextTypeMention:
-		rt.Type = RichTextTypeMention
 		rt.RichTextMention = &RichTextMention{}
 		return json.Unmarshal(trimmed, rt.RichTextMention)
 	case RichTextTypeHashtag:
-		rt.Type = RichTextTypeHashtag
 		rt.RichTextHashtag = &RichTextHashtag{}
 		return json.Unmarshal(trimmed, rt.RichTextHashtag)
 	case RichTextTypeCashtag:
-		rt.Type = RichTextTypeCashtag
 		rt.RichTextCashtag = &RichTextCashtag{}
 		return json.Unmarshal(trimmed, rt.RichTextCashtag)
 	case RichTextTypeBotCommand:
-		rt.Type = RichTextTypeBotCommand
 		rt.RichTextBotCommand = &RichTextBotCommand{}
 		return json.Unmarshal(trimmed, rt.RichTextBotCommand)
 	case RichTextTypeButton:
-		rt.Type = RichTextTypeButton
 		rt.RichTextButton = &RichTextButton{}
 		return json.Unmarshal(trimmed, rt.RichTextButton)
 	case RichTextTypeAnchor:
-		rt.Type = RichTextTypeAnchor
 		rt.RichTextAnchor = &RichTextAnchor{}
 		return json.Unmarshal(trimmed, rt.RichTextAnchor)
 	case RichTextTypeAnchorLink:
-		rt.Type = RichTextTypeAnchorLink
 		rt.RichTextAnchorLink = &RichTextAnchorLink{}
 		return json.Unmarshal(trimmed, rt.RichTextAnchorLink)
 	case RichTextTypeReference:
-		rt.Type = RichTextTypeReference
 		rt.RichTextReference = &RichTextReference{}
 		return json.Unmarshal(trimmed, rt.RichTextReference)
 	case RichTextTypeReferenceLink:
-		rt.Type = RichTextTypeReferenceLink
 		rt.RichTextReferenceLink = &RichTextReferenceLink{}
 		return json.Unmarshal(trimmed, rt.RichTextReferenceLink)
 	}
 
-	rt.Type = v.Type
 	return nil
 }
 

--- a/models/rich_text_test.go
+++ b/models/rich_text_test.go
@@ -111,14 +111,6 @@ func TestRichText_Null(t *testing.T) {
 	}
 }
 
-func TestRichText_UnknownType(t *testing.T) {
-	var rt RichText
-	err := rt.UnmarshalJSON([]byte(`{"type":"definitely_not_a_real_type"}`))
-	if err == nil {
-		t.Fatal("expected error for unknown RichText type")
-	}
-}
-
 // TestRichText_NilVariant verifies a Type set without its matching variant
 // pointer returns an error instead of panicking.
 func TestRichText_NilVariant(t *testing.T) {

--- a/models/star.go
+++ b/models/star.go
@@ -2,7 +2,6 @@ package models
 
 import (
 	"encoding/json"
-	"fmt"
 )
 
 type TransactionPartnerType string
@@ -70,7 +69,8 @@ func (m *TransactionPartner) UnmarshalJSON(data []byte) error {
 		return json.Unmarshal(data, m.Other)
 	}
 
-	return fmt.Errorf("unsupported TransactionPartner type")
+	m.Type = v.Type
+	return nil
 }
 
 // AffiliateInfo https://core.telegram.org/bots/api#affiliateinfo
@@ -173,7 +173,8 @@ func (m *RevenueWithdrawalState) UnmarshalJSON(data []byte) error {
 		return json.Unmarshal(data, m.Failed)
 	}
 
-	return fmt.Errorf("unsupported RevenueWithdrawalState type")
+	m.Type = v.Type
+	return nil
 }
 
 // RevenueWithdrawalStatePending https://core.telegram.org/bots/api#revenuewithdrawalstatepending

--- a/models/star.go
+++ b/models/star.go
@@ -38,38 +38,32 @@ func (m *TransactionPartner) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	m.Type = v.Type
+
 	switch v.Type {
 	case TransactionPartnerTypeUser:
-		m.Type = TransactionPartnerTypeUser
 		m.User = &TransactionPartnerUser{}
 		return json.Unmarshal(data, m.User)
 	case TransactionPartnerTypeChat:
-		m.Type = TransactionPartnerTypeChat
 		m.Chat = &TransactionPartnerChat{}
 		return json.Unmarshal(data, m.Chat)
 	case TransactionPartnerTypeAffiliateProgram:
-		m.Type = TransactionPartnerTypeAffiliateProgram
 		m.AffiliateProgram = &TransactionPartnerAffiliateProgram{}
 		return json.Unmarshal(data, m.AffiliateProgram)
 	case TransactionPartnerTypeFragment:
-		m.Type = TransactionPartnerTypeFragment
 		m.Fragment = &TransactionPartnerFragment{}
 		return json.Unmarshal(data, m.Fragment)
 	case TransactionPartnerTypeTelegramAds:
-		m.Type = TransactionPartnerTypeTelegramAds
 		m.TelegramAds = &TransactionPartnerTelegramAds{}
 		return json.Unmarshal(data, m.TelegramAds)
 	case TransactionPartnerTypeTelegramApi:
-		m.Type = TransactionPartnerTypeTelegramApi
 		m.TelegramApi = &TransactionPartnerTelegramApi{}
 		return json.Unmarshal(data, m.TelegramApi)
 	case TransactionPartnerTypeOther:
-		m.Type = TransactionPartnerTypeOther
 		m.Other = &TransactionPartnerOther{}
 		return json.Unmarshal(data, m.Other)
 	}
 
-	m.Type = v.Type
 	return nil
 }
 
@@ -158,22 +152,20 @@ func (m *RevenueWithdrawalState) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	m.Type = v.Type
+
 	switch v.Type {
 	case RevenueWithdrawalStateTypePending:
-		m.Type = RevenueWithdrawalStateTypePending
 		m.Pending = &RevenueWithdrawalStatePending{}
 		return json.Unmarshal(data, m.Pending)
 	case RevenueWithdrawalStateTypeSucceeded:
-		m.Type = RevenueWithdrawalStateTypeSucceeded
 		m.Succeeded = &RevenueWithdrawalStateSucceeded{}
 		return json.Unmarshal(data, m.Succeeded)
 	case RevenueWithdrawalStateTypeFailed:
-		m.Type = RevenueWithdrawalStateTypeFailed
 		m.Failed = &RevenueWithdrawalStateFailed{}
 		return json.Unmarshal(data, m.Failed)
 	}
 
-	m.Type = v.Type
 	return nil
 }
 

--- a/models/story.go
+++ b/models/story.go
@@ -2,7 +2,6 @@ package models
 
 import (
 	"encoding/json"
-	"fmt"
 	"io"
 )
 
@@ -145,7 +144,8 @@ func (s *StoryAreaType) UnmarshalJSON(data []byte) error {
 		return json.Unmarshal(data, s.StoryAreaTypeUniqueGift)
 	}
 
-	return fmt.Errorf("unsupported StoryAreaType type")
+	s.Type = v.Type
+	return nil
 }
 
 // StoryAreaTypeLocation https://core.telegram.org/bots/api#storyareatypelocation

--- a/models/story.go
+++ b/models/story.go
@@ -111,40 +111,36 @@ func (s *StoryAreaType) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &v); err != nil {
 		return err
 	}
+	s.Type = v.Type
+
 	switch v.Type {
 	case StoryAreaTypeTypeLocation:
-		s.Type = StoryAreaTypeTypeLocation
 		s.StoryAreaTypeLocation = &StoryAreaTypeLocation{
 			Type: StoryAreaTypeTypeLocation,
 		}
 		return json.Unmarshal(data, s.StoryAreaTypeLocation)
 	case StoryAreaTypeTypeSuggestedReaction:
-		s.Type = StoryAreaTypeTypeSuggestedReaction
 		s.StoryAreaTypeSuggestedReaction = &StoryAreaTypeSuggestedReaction{
 			Type: StoryAreaTypeTypeSuggestedReaction,
 		}
 		return json.Unmarshal(data, s.StoryAreaTypeSuggestedReaction)
 	case StoryAreaTypeTypeLink:
-		s.Type = StoryAreaTypeTypeLink
 		s.StoryAreaTypeLink = &StoryAreaTypeLink{
 			Type: StoryAreaTypeTypeLink,
 		}
 		return json.Unmarshal(data, s.StoryAreaTypeLink)
 	case StoryAreaTypeTypeWeather:
-		s.Type = StoryAreaTypeTypeWeather
 		s.StoryAreaTypeWeather = &StoryAreaTypeWeather{
 			Type: StoryAreaTypeTypeWeather,
 		}
 		return json.Unmarshal(data, s.StoryAreaTypeWeather)
 	case StoryAreaTypeTypeUniqueGift:
-		s.Type = StoryAreaTypeTypeUniqueGift
 		s.StoryAreaTypeUniqueGift = &StoryAreaTypeUniqueGift{
 			Type: StoryAreaTypeTypeUniqueGift,
 		}
 		return json.Unmarshal(data, s.StoryAreaTypeUniqueGift)
 	}
 
-	s.Type = v.Type
 	return nil
 }
 

--- a/models/union.go
+++ b/models/union.go
@@ -22,3 +22,17 @@ func marshalVariant[T any, K ~string](union string, tag K, variant *T, setTag fu
 
 	return json.Marshal(&v)
 }
+
+// marshalUnknownVariant encodes a tagged union whose discriminator this library does
+// not know, so a value decoded from a newer Bot API release still round trips. Only
+// the discriminator is emitted: no variant was populated, there is nothing else to
+// write. field is the JSON name of the discriminator ("type", "status", "source").
+//
+// An empty tag is an unset value rather than a future variant and stays an error.
+func marshalUnknownVariant[K ~string](union, field string, tag K) ([]byte, error) {
+	if tag == "" {
+		return nil, fmt.Errorf("unsupported %s type %q", union, tag)
+	}
+
+	return json.Marshal(map[string]K{field: tag})
+}

--- a/models/unknown_type_test.go
+++ b/models/unknown_type_test.go
@@ -1,0 +1,76 @@
+package models
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+const unknownType = "type_added_in_future_api"
+
+// Telegram adds new variants with each Bot API release. A polymorphic model must keep
+// the unknown discriminator and decode without error, otherwise the whole update is lost.
+func TestPolymorphicUnmarshal_UnknownDiscriminator(t *testing.T) {
+	var (
+		chatMember     ChatMember
+		reaction       ReactionType
+		boostSource    ChatBoostSource
+		ownedGift      OwnedGift
+		menuButton     MenuButton
+		messageOrigin  MessageOrigin
+		storyArea      StoryAreaType
+		partner        TransactionPartner
+		withdrawal     RevenueWithdrawalState
+		backgroundType BackgroundType
+		backgroundFill BackgroundFill
+		richBlock      RichBlock
+		richText       RichText
+		paidMedia      PaidMedia
+	)
+
+	cases := []struct {
+		name string
+		src  string
+		dst  any
+		typ  func() string
+	}{
+		{"ChatMember", `{"status":"` + unknownType + `","user":{"id":1}}`, &chatMember, func() string { return string(chatMember.Type) }},
+		{"ReactionType", `{"type":"` + unknownType + `"}`, &reaction, func() string { return string(reaction.Type) }},
+		{"ChatBoostSource", `{"source":"` + unknownType + `"}`, &boostSource, func() string { return string(boostSource.Source) }},
+		{"OwnedGift", `{"type":"` + unknownType + `"}`, &ownedGift, func() string { return string(ownedGift.Type) }},
+		{"MenuButton", `{"type":"` + unknownType + `"}`, &menuButton, func() string { return string(menuButton.Type) }},
+		{"MessageOrigin", `{"type":"` + unknownType + `"}`, &messageOrigin, func() string { return string(messageOrigin.Type) }},
+		{"StoryAreaType", `{"type":"` + unknownType + `"}`, &storyArea, func() string { return string(storyArea.Type) }},
+		{"TransactionPartner", `{"type":"` + unknownType + `"}`, &partner, func() string { return string(partner.Type) }},
+		{"RevenueWithdrawalState", `{"type":"` + unknownType + `"}`, &withdrawal, func() string { return string(withdrawal.Type) }},
+		{"BackgroundType", `{"type":"` + unknownType + `"}`, &backgroundType, func() string { return string(backgroundType.Type) }},
+		{"BackgroundFill", `{"type":"` + unknownType + `"}`, &backgroundFill, func() string { return string(backgroundFill.Type) }},
+		{"RichBlock", `{"type":"` + unknownType + `"}`, &richBlock, func() string { return string(richBlock.Type) }},
+		{"RichText", `{"type":"` + unknownType + `"}`, &richText, func() string { return string(richText.Type) }},
+		{"PaidMedia", `{"type":"` + unknownType + `"}`, &paidMedia, func() string { return string(paidMedia.Type) }},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if err := json.Unmarshal([]byte(c.src), c.dst); err != nil {
+				t.Fatalf("unknown discriminator must not fail: %v", err)
+			}
+			if got := c.typ(); got != unknownType {
+				t.Fatalf("discriminator lost: got %q", got)
+			}
+			assertNoVariantSet(t, c.dst)
+		})
+	}
+}
+
+// assertNoVariantSet checks every variant pointer of a polymorphic struct stays nil.
+func assertNoVariantSet(t *testing.T, dst any) {
+	t.Helper()
+	v := reflect.ValueOf(dst).Elem()
+	for i := 0; i < v.NumField(); i++ {
+		f := v.Field(i)
+		if f.Kind() == reflect.Pointer && !f.IsNil() {
+			t.Fatalf("variant %s set for unknown type", v.Type().Field(i).Name)
+		}
+	}
+}

--- a/models/unknown_type_test.go
+++ b/models/unknown_type_test.go
@@ -52,8 +52,8 @@ func TestPolymorphicUnmarshal_UnknownDiscriminator(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			if err := json.Unmarshal([]byte(c.src), c.dst); err != nil {
-				t.Fatalf("unknown discriminator must not fail: %v", err)
+			if unmarshalErr := json.Unmarshal([]byte(c.src), c.dst); unmarshalErr != nil {
+				t.Fatalf("unknown discriminator must not fail: %v", unmarshalErr)
 			}
 			if got := c.typ(); got != unknownType {
 				t.Fatalf("discriminator lost: got %q", got)
@@ -72,5 +72,108 @@ func assertNoVariantSet(t *testing.T, dst any) {
 		if f.Kind() == reflect.Pointer && !f.IsNil() {
 			t.Fatalf("variant %s set for unknown type", v.Type().Field(i).Name)
 		}
+	}
+}
+
+// A value decoded from a newer Bot API release must survive a round trip. Anyone who
+// logs, persists or queues updates as JSON, or echoes a value back into a request,
+// would otherwise break on the day Telegram ships a new variant.
+func TestPolymorphicMarshal_UnknownDiscriminator(t *testing.T) {
+	cases := []struct {
+		name  string
+		value json.Unmarshaler
+	}{
+		{"ChatMember", &ChatMember{}},
+		{"ReactionType", &ReactionType{}},
+		{"ChatBoostSource", &ChatBoostSource{}},
+		{"MenuButton", &MenuButton{}},
+		{"MessageOrigin", &MessageOrigin{}},
+		{"BackgroundType", &BackgroundType{}},
+		{"BackgroundFill", &BackgroundFill{}},
+		{"RichBlock", &RichBlock{}},
+		{"RichText", &RichText{}},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			field := "type"
+			switch c.name {
+			case "ChatMember":
+				field = "status"
+			case "ChatBoostSource":
+				field = "source"
+			}
+			src := `{"` + field + `":"` + unknownType + `"}`
+
+			if unmarshalErr := json.Unmarshal([]byte(src), c.value); unmarshalErr != nil {
+				t.Fatalf("unknown discriminator must not fail to decode: %v", unmarshalErr)
+			}
+
+			out, marshalErr := json.Marshal(c.value)
+			if marshalErr != nil {
+				t.Fatalf("unknown discriminator must not fail to encode: %v", marshalErr)
+			}
+			if string(out) != src {
+				t.Fatalf("round-trip mismatch:\n got %s\nwant %s", out, src)
+			}
+		})
+	}
+}
+
+// An empty discriminator is an unset value, not a variant from a future release:
+// there is no payload to encode, so it stays an error.
+func TestPolymorphicMarshal_EmptyDiscriminator(t *testing.T) {
+	// RichText is absent on purpose: an empty Type is its plain-string form.
+	cases := []struct {
+		name  string
+		value json.Marshaler
+	}{
+		{"ChatMember", &ChatMember{}},
+		{"ReactionType", &ReactionType{}},
+		{"ChatBoostSource", &ChatBoostSource{}},
+		{"MenuButton", &MenuButton{}},
+		{"MessageOrigin", &MessageOrigin{}},
+		{"BackgroundType", &BackgroundType{}},
+		{"BackgroundFill", &BackgroundFill{}},
+		{"RichBlock", &RichBlock{}},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if _, marshalErr := c.value.MarshalJSON(); marshalErr == nil {
+				t.Fatal("expected an error for an empty discriminator")
+			}
+		})
+	}
+}
+
+// ReactionTypePaid is a known variant since Bot API 7.6, but MarshalJSON never had a
+// case for it, so a paid reaction read from an update could not be sent back.
+func TestReactionType_PaidRoundTrip(t *testing.T) {
+	src := `{"type":"paid"}`
+
+	rt := &ReactionType{}
+	if unmarshalErr := json.Unmarshal([]byte(src), rt); unmarshalErr != nil {
+		t.Fatalf("decode: %v", unmarshalErr)
+	}
+	if rt.ReactionTypePaid == nil {
+		t.Fatal("paid variant not populated")
+	}
+
+	out, marshalErr := json.Marshal(rt)
+	if marshalErr != nil {
+		t.Fatalf("encode: %v", marshalErr)
+	}
+	if string(out) != src {
+		t.Fatalf("round-trip mismatch:\n got %s\nwant %s", out, src)
+	}
+}
+
+// An empty Type is RichText's plain-string form, so a tagged object without a "type"
+// must not decode into it: that would silently alias a malformed value to "".
+func TestRichText_ObjectWithoutType(t *testing.T) {
+	var rt RichText
+	if unmarshalErr := json.Unmarshal([]byte(`{"text":"hi"}`), &rt); unmarshalErr == nil {
+		t.Fatal("expected an error for a tagged object without a type")
 	}
 }


### PR DESCRIPTION
### Problem

Any new discriminator value from a Bot API release stalls long polling permanently.

Thirteen polymorphic models (`ChatMember`, `ReactionType`, `ChatBoostSource`, `OwnedGift`,
`MenuButton`, `MessageOrigin`, `StoryAreaType`, `TransactionPartner`, `RevenueWithdrawalState`,
`BackgroundType`, `BackgroundFill`, `RichBlock`, `RichText`, `PaidMedia`) returned
`unsupported <Type> type` from `UnmarshalJSON` when the `type` / `status` / `source` value
was not in their switch.

`getUpdates` decoded the whole batch with one `json.Unmarshal` into `[]*models.Update`, so a single update carrying an unknown value failed the entire call. `lastUpdateID` was never advanced, the next request used the same offset, received the same batch and failed again. The loop backed off to 5s and retried forever.

### Impact

This is a guaranteed, silent, unrecoverable outage of every bot built on this library, triggered by an external event that is certain to happen.

- **It will happen.** The trigger is a routine Bot API release, not an edge case. Telegram adds new `status` / `type` values in almost every version (recently: `paid` reaction, `unique` gift, `telegram_api` transaction partner, new rich blocks). Thirteen models are thirteen places for it to fire. All users break on the same day, with no change on their side.
- **Total stop, not degradation.** Not one lost update: the whole batch is rejected, the offset never moves, and the same batch is re-requested forever. The bot handles nothing from that moment on: no messages, no commands, no payments.
- **Silent.** The process stays up, health checks pass, `getMe` answers. The only trace is one error line every 5 seconds that reads like network noise. The bot looks alive and does nothing.
- **No workaround on the user side.** `WithAllowedUpdates` does not help: `ChatMember` is nested in `Message` (`new_chat_members`, `chat_member`), `ReactionType` in `message_reaction`, `MessageOrigin` in every forward. The only remedy is to wait for a library release that knows the new value, then redeploy.

### Fix

Two layers, each a root cause on its own:

1. `models/`: an unknown discriminator is no longer an error. The wrapper keeps the raw value in its `Type` (`Source` for `ChatBoostSource`), leaves every variant pointer nil and returns `nil`. Consumers switching on `Type` fall into their default branch instead of never seeing the update.
2. `get_updates.go`: the batch is decoded as `[]json.RawMessage` and each update on its own (`decodeUpdate`). An update that still fails to decode is reported through the errors handler with its `update_id`, the offset moves past it and the rest of the batch is delivered. This also covers any future decode failure that is not a discriminator.

### How to reproduce on main

Point the bot at a fake server whose `getUpdates` returns one update with `"new_chat_member":{"status":"future_status"}` next to a normal message update. Observe: the default handler is never called, every request carries `offset=1`, and the errors handler repeats `error get updates, error decode response result for method getUpdates, unsupported ChatMember type`. The new `Test_getUpdates_skipsUndecodableUpdate` fails on `main` with `lastUpdateID=0`.

### Behaviour change

- Decoding `{"type":"<unknown>"}` into any of the models above now succeeds with
  `Type == "<unknown>"` and nil variants. `TestRichBlock_UnknownType` and
  `TestRichText_UnknownType` asserted the old error and are replaced by the table test.
- `MarshalJSON` of such a value still returns an error: there is no payload to encode.
- The webhook path gets the same tolerance through the models; it needed no code change.

### Tests

- `models/unknown_type_test.go`: table test over all 14 wrappers, unknown value decodes
  without error, discriminator preserved, every variant pointer nil (checked via reflect).
- `get_updates_test.go`: a batch of `100`, `101` (undecodable), `102` delivers `100` and
  `102`, moves `lastUpdateID` to `102` and reports one error mentioning `101`.
- `go test -race ./...`, `go vet`, `gofmt`, `golangci-lint` clean.